### PR TITLE
Support for user input pipelines

### DIFF
--- a/llvm/tools/llvm-lsp/IRDocument.h
+++ b/llvm/tools/llvm-lsp/IRDocument.h
@@ -14,6 +14,7 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/GraphWriter.h"
 #include "llvm/Support/SourceMgr.h"
@@ -269,13 +270,17 @@ public:
   }
 
   // N is 1-Indexed here, but IRA expects 0-Indexed
-  std::string getIRAfterPassNumber(const std::string &Pipeline, unsigned N) {
+  llvm::Expected<std::string> getIRAfterPassNumber(const std::string &Pipeline,
+                                                   unsigned N) {
     auto ExistingIR = IRA->getIRAfterPassNumber(N);
     if (ExistingIR) {
       LoggerObj.log("Found Existing IR");
       return *ExistingIR;
     }
-    auto PassName = Optimizer->getPassName(Pipeline, N);
+    auto PassNameResult = Optimizer->getPassName(Pipeline, N);
+    if (!PassNameResult)
+      return PassNameResult.takeError();
+    auto PassName = PassNameResult.get();
     LoggerObj.log("Found Pass name for pass number " + std::to_string(N) +
                   " as " + PassName);
 
@@ -288,22 +293,32 @@ public:
 
   // FIXME: We are doing some redundant work here in below functions, which can
   // be fused together.
-  const SmallVector<std::string, 256> getPassList(const std::string &Pipeline) {
+  llvm::Expected<SmallVector<std::string, 256>>
+  getPassList(const std::string &Pipeline) {
     SmallVector<std::string, 256> PassList;
-    auto PassNameAndDescriptionList =
+    auto PassNameAndDescriptionListResult =
         Optimizer->getPassListAndDescription(Pipeline);
 
-    for (auto &P : PassNameAndDescriptionList)
+    if (!PassNameAndDescriptionListResult) {
+      LoggerObj.log("Handling error in getPassList()");
+      return PassNameAndDescriptionListResult.takeError();
+    }
+
+    for (auto &P : PassNameAndDescriptionListResult.get())
       PassList.push_back(P.first);
 
     return PassList;
   }
-  const SmallVector<std::string, 256>
+  llvm::Expected<SmallVector<std::string, 256>>
   getPassDescriptions(const std::string &Pipeline) {
     SmallVector<std::string, 256> PassDesc;
-    auto PassNameAndDescriptionList =
+    auto PassNameAndDescriptionListResult =
         Optimizer->getPassListAndDescription(Pipeline);
-    for (auto &P : PassNameAndDescriptionList)
+
+    if (!PassNameAndDescriptionListResult)
+      return PassNameAndDescriptionListResult.takeError();
+
+    for (auto &P : PassNameAndDescriptionListResult.get())
       PassDesc.push_back(P.second);
 
     return PassDesc;

--- a/llvm/tools/llvm-lsp/IRDocument.h
+++ b/llvm/tools/llvm-lsp/IRDocument.h
@@ -285,6 +285,10 @@ public:
                   " as " + PassName);
 
     auto IntermediateIR = Optimizer->getModuleAfterPass(Pipeline, N);
+    if (!IntermediateIR) {
+      LoggerObj.log("Error while getting intermediate IR");
+      return IntermediateIR.takeError();
+    }
     LoggerObj.log("Got intermediate IR. Storing it in Artifacts Directory!");
     IRA->addIntermediateIR(*IntermediateIR.get(), N, PassName);
     LoggerObj.log("Finished storing in Artifacts directory!");

--- a/llvm/tools/llvm-lsp/IRDocument.h
+++ b/llvm/tools/llvm-lsp/IRDocument.h
@@ -269,17 +269,17 @@ public:
   }
 
   // N is 1-Indexed here, but IRA expects 0-Indexed
-  std::string getIRAfterPassNumber(unsigned N) {
+  std::string getIRAfterPassNumber(const std::string &Pipeline, unsigned N) {
     auto ExistingIR = IRA->getIRAfterPassNumber(N);
     if (ExistingIR) {
       LoggerObj.log("Found Existing IR");
       return *ExistingIR;
     }
-    auto PassName = Optimizer->getPassName("default<O3>", N);
+    auto PassName = Optimizer->getPassName(Pipeline, N);
     LoggerObj.log("Found Pass name for pass number " + std::to_string(N) +
                   " as " + PassName);
 
-    auto IntermediateIR = Optimizer->getModuleAfterPass("default<O3>", N);
+    auto IntermediateIR = Optimizer->getModuleAfterPass(Pipeline, N);
     LoggerObj.log("Got intermediate IR. Storing it in Artifacts Directory!");
     IRA->addIntermediateIR(*IntermediateIR.get(), N, PassName);
     LoggerObj.log("Finished storing in Artifacts directory!");
@@ -288,20 +288,21 @@ public:
 
   // FIXME: We are doing some redundant work here in below functions, which can
   // be fused together.
-  const SmallVector<std::string, 256> getPassList() {
+  const SmallVector<std::string, 256> getPassList(const std::string &Pipeline) {
     SmallVector<std::string, 256> PassList;
     auto PassNameAndDescriptionList =
-        Optimizer->getPassListAndDescription("default<O3>");
+        Optimizer->getPassListAndDescription(Pipeline);
 
     for (auto &P : PassNameAndDescriptionList)
       PassList.push_back(P.first);
 
     return PassList;
   }
-  const SmallVector<std::string, 256> getPassDescriptions() {
+  const SmallVector<std::string, 256>
+  getPassDescriptions(const std::string &Pipeline) {
     SmallVector<std::string, 256> PassDesc;
     auto PassNameAndDescriptionList =
-        Optimizer->getPassListAndDescription("default<O3>");
+        Optimizer->getPassListAndDescription(Pipeline);
     for (auto &P : PassNameAndDescriptionList)
       PassDesc.push_back(P.second);
 

--- a/llvm/tools/llvm-lsp/OptRunner.h
+++ b/llvm/tools/llvm-lsp/OptRunner.h
@@ -8,6 +8,7 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include <memory>
 #include <string>
@@ -27,7 +28,7 @@ class OptRunner {
 public:
   OptRunner(Module &IIR, Logger &LO) : LoggerObj(LO), InitialIR(IIR) {}
 
-  const SmallVector<std::pair<std::string, std::string>, 256>
+  llvm::Expected<SmallVector<std::pair<std::string, std::string>, 256>>
   getPassListAndDescription(const std::string PipelineText) {
     // First is Passname, Second is Pass Description.
     SmallVector<std::pair<std::string, std::string>, 256>
@@ -67,11 +68,15 @@ public:
           PassListAndDescription.push_back({PassNameStr, PassDescStr});
         };
 
-    runOpt(PipelineText, RecordPassNamesAndDescription);
+    auto RunOptResult = runOpt(PipelineText, RecordPassNamesAndDescription);
+    if (!RunOptResult) {
+      LoggerObj.log("Handling error in getPassListAndDescription()");
+      return RunOptResult.takeError();
+    }
     return PassListAndDescription;
   }
 
-  std::unique_ptr<Module>
+  llvm::Expected<std::unique_ptr<Module>>
   runOpt(const std::string PipelineText,
          std::function<void(const StringRef, Any, const PreservedAnalyses)>
              &AfterPassCallback) {
@@ -98,8 +103,10 @@ public:
 
     // Parse Pipeline text
     auto ParseError = PB.parsePassPipeline(MPM, PipelineText);
-    if (ParseError)
+    if (ParseError) {
       LoggerObj.log("Error parsing pipeline text!");
+      return llvm::createStringError(toString(std::move(ParseError)).c_str());
+    }
 
     // Run Opt on a copy of the original IR, so that we dont modify the original
     // IR.
@@ -111,8 +118,8 @@ public:
   // TODO: Check if N lies with in bounds for below methods. And to verify that
   // they are populated.
   // N is 1-Indexed
-  std::unique_ptr<Module> getModuleAfterPass(const std::string PipelineText,
-                                             unsigned N) {
+  llvm::Expected<std::unique_ptr<Module>>
+  getModuleAfterPass(const std::string PipelineText, unsigned N) {
     unsigned PassNumber = 0;
     std::unique_ptr<Module> IntermediateIR = nullptr;
     std::function<void(const StringRef, Any, const PreservedAnalyses)>
@@ -140,7 +147,10 @@ public:
           }
         };
 
-    runOpt(PipelineText, RecordIRAfterPass);
+    auto RunOptResult = runOpt(PipelineText, RecordIRAfterPass);
+    if (!RunOptResult) {
+      return RunOptResult.takeError();
+    }
 
     if (!IntermediateIR)
       LoggerObj.error("Unrecognized Pass Number " + std::to_string(N) + "!");
@@ -148,13 +158,15 @@ public:
     return IntermediateIR;
   }
 
-  std::unique_ptr<Module> getFinalModule(const std::string PipelineText) {
+  llvm::Expected<std::unique_ptr<Module>>
+  getFinalModule(const std::string PipelineText) {
     std::function<void(const StringRef, Any, const PreservedAnalyses)>
         EmptyCallback = [](const StringRef, Any, const PreservedAnalyses &) {};
     return runOpt(PipelineText, EmptyCallback);
   }
 
-  std::string getPassName(std::string PipelineText, unsigned N) {
+  llvm::Expected<std::string> getPassName(std::string PipelineText,
+                                          unsigned N) {
     unsigned PassNumber = 0;
     std::string IntermediatePassName = "";
     std::function<void(const StringRef, Any, const PreservedAnalyses)>
@@ -166,7 +178,10 @@ public:
                 IntermediatePassName = PassName.str();
             };
 
-    runOpt(PipelineText, RecordNameAfterPass);
+    auto RunOptResult = runOpt(PipelineText, RecordNameAfterPass);
+    if (!RunOptResult) {
+      return RunOptResult.takeError();
+    }
 
     if (IntermediatePassName == "")
       LoggerObj.error("Unrecognized Pass Number " + std::to_string(N) + "!");

--- a/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
+++ b/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
@@ -33,6 +33,13 @@ void LspServer::sendInfo(const std::string &Message) {
                    json::Value(std::move(NotificationParams)));
 }
 
+void LspServer::sendError(const std::string &Message) {
+  json::Object NotificationParams{{"type", 1}, // Info
+                                  {"message", Message}};
+  sendNotification(std::string("window/showMessage"),
+                   json::Value(std::move(NotificationParams)));
+}
+
 std::string LspServer::readMessage() {
   std::string Line;
   size_t ContentLength = 0;
@@ -320,9 +327,28 @@ void LspServer::handleRequestGetPassList(const json::Value *Id,
 
   LoggerObj.log("Opened IR file to get pass list " + Filepath.str());
 
-  auto PassList = Doc.getPassList(Pipeline);
+  auto PassListResult = Doc.getPassList(Pipeline);
 
-  auto PassDescriptions = Doc.getPassDescriptions(Pipeline);
+  if (!PassListResult) {
+    LoggerObj.log("Sending error");
+    sendErrorResponse(*Id, InvalidParams,
+                      "Error while getting pass list:" +
+                          toString(PassListResult.takeError()));
+    return;
+  }
+
+  auto PassList = PassListResult.get();
+
+  auto PassDescriptionsResult = Doc.getPassDescriptions(Pipeline);
+
+  if (!PassDescriptionsResult) {
+    sendErrorResponse(*Id, InvalidParams,
+                      "Error while getting pass descriptions:" +
+                          toString(PassDescriptionsResult.takeError()));
+    return;
+  }
+
+  auto PassDescriptions = PassDescriptionsResult.get();
 
   json::Array NameArray, DescArray;
   for (unsigned I = 0; I < PassList.size(); I++)
@@ -353,7 +379,15 @@ void LspServer::handleRequestGetIRAfterPass(const json::Value *Id,
   IRDocument &Doc = *OpenDocuments[Filepath.str()];
 
   unsigned PassNum = queryJSONForInt(Params, "passnumber");
-  std::string IRFilePath = Doc.getIRAfterPassNumber(Pipeline, PassNum);
+  auto IRFilePathResult = Doc.getIRAfterPassNumber(Pipeline, PassNum);
+
+  if (!IRFilePathResult) {
+    sendErrorResponse(*Id, InvalidParams,
+                      toString(IRFilePathResult.takeError()));
+    return;
+  }
+
+  auto IRFilePath = IRFilePathResult.get();
 
   json::Object ResponseParams{{"uri", "file://" + IRFilePath}};
 

--- a/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
+++ b/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
@@ -330,7 +330,6 @@ void LspServer::handleRequestGetPassList(const json::Value *Id,
   auto PassListResult = Doc.getPassList(Pipeline);
 
   if (!PassListResult) {
-    LoggerObj.log("Sending error");
     sendErrorResponse(*Id, InvalidParams,
                       "Error while getting pass list:" +
                           toString(PassListResult.takeError()));

--- a/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
+++ b/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
@@ -34,7 +34,7 @@ void LspServer::sendInfo(const std::string &Message) {
 }
 
 void LspServer::sendError(const std::string &Message) {
-  json::Object NotificationParams{{"type", 1}, // Info
+  json::Object NotificationParams{{"type", 1}, // Error
                                   {"message", Message}};
   sendNotification(std::string("window/showMessage"),
                    json::Value(std::move(NotificationParams)));

--- a/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
+++ b/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
@@ -312,6 +312,7 @@ void LspServer::handleRequestGetPassList(const json::Value *Id,
                                          const json::Value *Params) {
 
   StringRef Filepath = queryJSONForFilePath(Params, "uri");
+  std::string Pipeline = queryJSONForString(Params, "pipeline").str();
 
   if (OpenDocuments.find(Filepath.str()) == OpenDocuments.end())
     LoggerObj.error("Did not open file previously " + Filepath.str());
@@ -319,9 +320,9 @@ void LspServer::handleRequestGetPassList(const json::Value *Id,
 
   LoggerObj.log("Opened IR file to get pass list " + Filepath.str());
 
-  auto PassList = Doc.getPassList();
+  auto PassList = Doc.getPassList(Pipeline);
 
-  auto PassDescriptions = Doc.getPassDescriptions();
+  auto PassDescriptions = Doc.getPassDescriptions(Pipeline);
 
   json::Array NameArray, DescArray;
   for (unsigned I = 0; I < PassList.size(); I++)
@@ -345,13 +346,14 @@ void LspServer::handleRequestGetPassList(const json::Value *Id,
 void LspServer::handleRequestGetIRAfterPass(const json::Value *Id,
                                             const json::Value *Params) {
   StringRef Filepath = queryJSONForFilePath(Params, "uri");
+  std::string Pipeline = queryJSONForString(Params, "pipeline").str();
 
   if (OpenDocuments.find(Filepath.str()) == OpenDocuments.end())
     LoggerObj.error("Did not open file previously " + Filepath.str());
   IRDocument &Doc = *OpenDocuments[Filepath.str()];
 
   unsigned PassNum = queryJSONForInt(Params, "passnumber");
-  std::string IRFilePath = Doc.getIRAfterPassNumber(PassNum);
+  std::string IRFilePath = Doc.getIRAfterPassNumber(Pipeline, PassNum);
 
   json::Object ResponseParams{{"uri", "file://" + IRFilePath}};
 

--- a/llvm/tools/llvm-lsp/llvm-lsp-server.h
+++ b/llvm/tools/llvm-lsp/llvm-lsp-server.h
@@ -66,6 +66,9 @@ public:
   // Sends a message to client as INFO notification
   void sendInfo(const std::string &Message);
 
+  // Sends a message to client as ERROR notification
+  void sendError(const std::string &Message);
+
   // The process exit code, should be success only if the State is Exitted
   int getExitCode() { return State == LspServerState::Exitted ? 0 : 1; }
 


### PR DESCRIPTION
This adds support for user defined pipelines instead of the hardcoded default<O3>.

A parameter was added to the llvm/getPassList and llvm/getIRAfterPass, the user defined pipeline.

When user input was invalid, the server would crash on an unhandled error in runOpt, so I changed the return type to Expected<T> to propagate the error up, somewhere, where it can be handled and displayed to the user.