### PR TITLE
Fix location tracking

### DIFF
--- a/llvm/include/llvm/AsmParser/LLLexer.h
+++ b/llvm/include/llvm/AsmParser/LLLexer.h
@@ -99,6 +99,8 @@ namespace llvm {
     lltok::Kind LexToken();
 
     int getNextChar();
+    const char *skipNChars(unsigned N);
+    void advancePositionTo(const char *Ptr);
     void SkipLineComment();
     bool SkipCComment();
     lltok::Kind ReadString(lltok::Kind kind);

--- a/llvm/include/llvm/AsmParser/LLLexer.h
+++ b/llvm/include/llvm/AsmParser/LLLexer.h
@@ -77,13 +77,15 @@ namespace llvm {
                      LLVMContext &C);
 
     lltok::Kind Lex() {
-      // This is a hack for getting the next location, since the end is
+      // Set token end to next location, since the end is
       // exclusive
-      const char *BackupPtr = CurPtr;
-      getNextChar();
-      PrevTokEndLineNum = CurLineNum;
-      PrevTokEndColNum = CurColNum;
-      advancePositionTo(BackupPtr);
+      if (CurPtr != CurBuf.begin() && *(CurPtr - 1) == '\n') {
+        PrevTokEndLineNum = CurLineNum + 1;
+        PrevTokEndColNum = 0;
+      } else {
+        PrevTokEndLineNum = CurLineNum;
+        PrevTokEndColNum = CurColNum + 1;
+      }
 
       return CurKind = LexToken();
     }

--- a/llvm/include/llvm/AsmParser/LLLexer.h
+++ b/llvm/include/llvm/AsmParser/LLLexer.h
@@ -76,19 +76,7 @@ namespace llvm {
     explicit LLLexer(StringRef StartBuf, SourceMgr &SM, SMDiagnostic &,
                      LLVMContext &C);
 
-    lltok::Kind Lex() {
-      // Set token end to next location, since the end is
-      // exclusive
-      if (CurPtr != CurBuf.begin() && *(CurPtr - 1) == '\n') {
-        PrevTokEndLineNum = CurLineNum + 1;
-        PrevTokEndColNum = 0;
-      } else {
-        PrevTokEndLineNum = CurLineNum;
-        PrevTokEndColNum = CurColNum + 1;
-      }
-
-      return CurKind = LexToken();
-    }
+    lltok::Kind Lex() { return CurKind = LexToken(); }
 
     typedef SMLoc LocTy;
     LocTy getLoc() const { return SMLoc::getFromPointer(TokStart); }

--- a/llvm/include/llvm/AsmParser/LLLexer.h
+++ b/llvm/include/llvm/AsmParser/LLLexer.h
@@ -101,11 +101,19 @@ namespace llvm {
       IgnoreColonInIdentifiers = val;
     }
 
+    // Get the current line number, zero-indexed
     unsigned getLineNum() { return CurLineNum; }
+    // Get the current column number, zero-indexed
     unsigned getColNum() { return CurColNum; }
+    // Get the line number of the start of the current token, zero-indexed
     unsigned getTokLineNum() { return CurTokLineNum; }
+    // Get the column number of the start of the current token, zero-indexed
     unsigned getTokColNum() { return CurTokColNum; }
+    // Get the line number of the end of the previous token, zero-indexed,
+    // exclusive
     unsigned getPrevTokEndLineNum() { return PrevTokEndLineNum; }
+    // Get the column number of the end of the previous token, zero-indexed,
+    // exclusive
     unsigned getPrevTokEndColNum() { return PrevTokEndColNum; }
 
     // This returns true as a convenience for the parser functions that return

--- a/llvm/include/llvm/AsmParser/LLLexer.h
+++ b/llvm/include/llvm/AsmParser/LLLexer.h
@@ -28,8 +28,20 @@ namespace llvm {
   class LLLexer {
     const char *CurPtr;
     StringRef CurBuf;
+
+    // The line number at `CurPtr-1`, zero-indexed
     unsigned CurLineNum = 0;
-    unsigned CurColNum = 0;
+    // The column number at `CurPtr-1`, zero-indexed
+    unsigned CurColNum = -1;
+    // The line number of the start of the current token, zero-indexed
+    unsigned CurTokLineNum = 0;
+    // The column number of the start of the current token, zero-indexed
+    unsigned CurTokColNum = 0;
+    // The line number of the end of the current token, zero-indexed
+    unsigned PrevTokEndLineNum = -1;
+    // The column number of the end (exclusive) of the current token,
+    // zero-indexed
+    unsigned PrevTokEndColNum = -1;
 
     enum class ErrorPriority {
       None,   // No error message present.
@@ -65,6 +77,14 @@ namespace llvm {
                      LLVMContext &C);
 
     lltok::Kind Lex() {
+      // This is a hack for getting the next location, since the end is
+      // exclusive
+      const char *BackupPtr = CurPtr;
+      getNextChar();
+      PrevTokEndLineNum = CurLineNum;
+      PrevTokEndColNum = CurColNum;
+      advancePositionTo(BackupPtr);
+
       return CurKind = LexToken();
     }
 
@@ -83,6 +103,10 @@ namespace llvm {
 
     unsigned getLineNum() { return CurLineNum; }
     unsigned getColNum() { return CurColNum; }
+    unsigned getTokLineNum() { return CurTokLineNum; }
+    unsigned getTokColNum() { return CurTokColNum; }
+    unsigned getPrevTokEndLineNum() { return PrevTokEndLineNum; }
+    unsigned getPrevTokEndColNum() { return PrevTokEndColNum; }
 
     // This returns true as a convenience for the parser functions that return
     // true on error.

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -203,13 +203,23 @@ const char *LLLexer::skipNChars(unsigned N) {
 }
 
 void LLLexer::advancePositionTo(const char *Ptr) {
+  bool RecalculateColumn = false;
   while (CurPtr != Ptr) {
-    // FIXME: Assumes that if moving back, we stay in that line
     if (CurPtr > Ptr) {
       --CurPtr;
       --CurColNum;
+      if (*(CurPtr - 1) == '\n') {
+        --CurLineNum;
+        RecalculateColumn = true;
+      }
     } else
       getNextChar();
+  }
+  if (RecalculateColumn) {
+    CurColNum = 0;
+    for (const char *Ptr = CurPtr; Ptr != CurBuf.begin() || *(Ptr - 1) != '\n';
+         --Ptr, ++CurColNum)
+      ;
   }
 }
 

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -176,6 +176,8 @@ LLLexer::LLLexer(StringRef StartBuf, SourceMgr &SM, SMDiagnostic &Err,
 
 int LLLexer::getNextChar() {
   char CurChar = *CurPtr++;
+  // Increment line number if this is the first character after a newline
+  // CurPtr points to the char after CurChar, so two positions before that
   if ((CurPtr - 2) >= CurBuf.begin() && *(CurPtr - 2) == '\n') {
     CurLineNum++;
     CurColNum = 0;
@@ -208,7 +210,9 @@ void LLLexer::advancePositionTo(const char *Ptr) {
     if (CurPtr > Ptr) {
       --CurPtr;
       --CurColNum;
-      if (*(CurPtr - 1) == '\n') {
+      // Since CurPtr is one char ahead of the stored position, chech if the
+      // previous char is not a newline
+      if (CurPtr != CurBuf.begin() && *(CurPtr - 1) == '\n') {
         --CurLineNum;
         RecalculateColumn = true;
       }
@@ -217,6 +221,7 @@ void LLLexer::advancePositionTo(const char *Ptr) {
   }
   if (RecalculateColumn) {
     CurColNum = 0;
+    // Count the number of chars to the previous newline or start of buffer
     for (const char *Ptr = CurPtr; Ptr != CurBuf.begin() && *(Ptr - 1) != '\n';
          --Ptr, ++CurColNum)
       ;

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -196,6 +196,23 @@ int LLLexer::getNextChar() {
   }
 }
 
+const char *LLLexer::skipNChars(unsigned N) {
+  while (N--)
+    getNextChar();
+  return CurPtr;
+}
+
+void LLLexer::advancePositionTo(const char *Ptr) {
+  while (CurPtr != Ptr) {
+    // FIXME: Assumes that if moving back, we stay in that line
+    if (CurPtr > Ptr) {
+      --CurPtr;
+      --CurColNum;
+    } else
+      getNextChar();
+  }
+}
+
 lltok::Kind LLLexer::LexToken() {
   while (true) {
     TokStart = CurPtr;
@@ -222,12 +239,12 @@ lltok::Kind LLLexer::LexToken() {
     case '"': return LexQuote();
     case '.':
       if (const char *Ptr = isLabelTail(CurPtr)) {
-        CurPtr = Ptr;
+        advancePositionTo(Ptr);
         StrVal.assign(TokStart, CurPtr-1);
         return lltok::LabelStr;
       }
       if (CurPtr[0] == '.' && CurPtr[1] == '.') {
-        CurPtr += 2;
+        skipNChars(2);
         return lltok::dotdotdot;
       }
       return lltok::Error;
@@ -305,14 +322,14 @@ lltok::Kind LLLexer::LexAt() {
 
 lltok::Kind LLLexer::LexDollar() {
   if (const char *Ptr = isLabelTail(TokStart)) {
-    CurPtr = Ptr;
+    advancePositionTo(Ptr);
     StrVal.assign(TokStart, CurPtr - 1);
     return lltok::LabelStr;
   }
 
   // Handle DollarStringConstant: $\"[^\"]*\"
   if (CurPtr[0] == '"') {
-    ++CurPtr;
+    getNextChar();
 
     while (true) {
       int CurChar = getNextChar();
@@ -364,11 +381,11 @@ bool LLLexer::ReadVarName() {
   if (isalpha(static_cast<unsigned char>(CurPtr[0])) ||
       CurPtr[0] == '-' || CurPtr[0] == '$' ||
       CurPtr[0] == '.' || CurPtr[0] == '_') {
-    ++CurPtr;
+    getNextChar();
     while (isalnum(static_cast<unsigned char>(CurPtr[0])) ||
            CurPtr[0] == '-' || CurPtr[0] == '$' ||
            CurPtr[0] == '.' || CurPtr[0] == '_')
-      ++CurPtr;
+      getNextChar();
 
     StrVal.assign(NameStart, CurPtr);
     return true;
@@ -382,7 +399,8 @@ lltok::Kind LLLexer::LexUIntID(lltok::Kind Token) {
   if (!isdigit(static_cast<unsigned char>(CurPtr[0])))
     return lltok::Error;
 
-  for (++CurPtr; isdigit(static_cast<unsigned char>(CurPtr[0])); ++CurPtr)
+  for (getNextChar(); isdigit(static_cast<unsigned char>(CurPtr[0]));
+       getNextChar())
     /*empty*/;
 
   uint64_t Val = atoull(TokStart + 1, CurPtr);
@@ -395,7 +413,7 @@ lltok::Kind LLLexer::LexUIntID(lltok::Kind Token) {
 lltok::Kind LLLexer::LexVar(lltok::Kind Var, lltok::Kind VarID) {
   // Handle StringConstant: \"[^\"]*\"
   if (CurPtr[0] == '"') {
-    ++CurPtr;
+    getNextChar();
 
     while (true) {
       int CurChar = getNextChar();
@@ -441,7 +459,7 @@ lltok::Kind LLLexer::LexQuote() {
     return kind;
 
   if (CurPtr[0] == ':') {
-    ++CurPtr;
+    getNextChar();
     if (StringRef(StrVal).contains(0)) {
       LexError("NUL character is not allowed in names");
       kind = lltok::Error;
@@ -461,11 +479,11 @@ lltok::Kind LLLexer::LexExclaim() {
   if (isalpha(static_cast<unsigned char>(CurPtr[0])) ||
       CurPtr[0] == '-' || CurPtr[0] == '$' ||
       CurPtr[0] == '.' || CurPtr[0] == '_' || CurPtr[0] == '\\') {
-    ++CurPtr;
+    getNextChar();
     while (isalnum(static_cast<unsigned char>(CurPtr[0])) ||
            CurPtr[0] == '-' || CurPtr[0] == '$' ||
            CurPtr[0] == '.' || CurPtr[0] == '_' || CurPtr[0] == '\\')
-      ++CurPtr;
+      getNextChar();
 
     StrVal.assign(TokStart+1, CurPtr);   // Skip !
     UnEscapeLexed(StrVal);
@@ -501,7 +519,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   const char *IntEnd = CurPtr[-1] == 'i' ? nullptr : StartChar;
   const char *KeywordEnd = nullptr;
 
-  for (; isLabelChar(*CurPtr); ++CurPtr) {
+  for (; isLabelChar(*CurPtr); getNextChar()) {
     // If we decide this is an integer, remember the end of the sequence.
     if (!IntEnd && !isdigit(static_cast<unsigned char>(*CurPtr)))
       IntEnd = CurPtr;
@@ -513,7 +531,8 @@ lltok::Kind LLLexer::LexIdentifier() {
   // If we stopped due to a colon, unless we were directed to ignore it,
   // this really is a label.
   if (!IgnoreColonInIdentifiers && *CurPtr == ':') {
-    StrVal.assign(StartChar-1, CurPtr++);
+    StrVal.assign(StartChar - 1, CurPtr);
+    getNextChar();
     return lltok::LabelStr;
   }
 
@@ -521,7 +540,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   // return it.
   if (!IntEnd) IntEnd = CurPtr;
   if (IntEnd != StartChar) {
-    CurPtr = IntEnd;
+    advancePositionTo(IntEnd);
     uint64_t NumBits = atoull(StartChar, CurPtr);
     if (NumBits < IntegerType::MIN_INT_BITS ||
         NumBits > IntegerType::MAX_INT_BITS) {
@@ -534,7 +553,7 @@ lltok::Kind LLLexer::LexIdentifier() {
 
   // Otherwise, this was a letter sequence.  See which keyword this is.
   if (!KeywordEnd) KeywordEnd = CurPtr;
-  CurPtr = KeywordEnd;
+  advancePositionTo(KeywordEnd);
   --StartChar;
   StringRef Keyword(StartChar, CurPtr - StartChar);
 
@@ -1047,7 +1066,7 @@ lltok::Kind LLLexer::LexIdentifier() {
     StringRef HexStr(TokStart + 3, len);
     if (!all_of(HexStr, isxdigit)) {
       // Bad token, return it as an error.
-      CurPtr = TokStart+3;
+      advancePositionTo(TokStart + 3);
       return lltok::Error;
     }
     APInt Tmp(bits, HexStr, 16);
@@ -1060,12 +1079,12 @@ lltok::Kind LLLexer::LexIdentifier() {
 
   // If this is "cc1234", return this as just "cc".
   if (TokStart[0] == 'c' && TokStart[1] == 'c') {
-    CurPtr = TokStart+2;
+    advancePositionTo(TokStart + 2);
     return lltok::kw_cc;
   }
 
   // Finally, if this isn't known, return an error.
-  CurPtr = TokStart+1;
+  advancePositionTo(TokStart + 1);
   return lltok::Error;
 }
 
@@ -1078,24 +1097,25 @@ lltok::Kind LLLexer::LexIdentifier() {
 ///    HexHalfConstant   0xH[0-9A-Fa-f]+
 ///    HexBFloatConstant 0xR[0-9A-Fa-f]+
 lltok::Kind LLLexer::Lex0x() {
-  CurPtr = TokStart + 2;
+  advancePositionTo(TokStart + 2);
 
   char Kind;
   if ((CurPtr[0] >= 'K' && CurPtr[0] <= 'M') || CurPtr[0] == 'H' ||
       CurPtr[0] == 'R') {
-    Kind = *CurPtr++;
+    Kind = *CurPtr;
+    getNextChar();
   } else {
     Kind = 'J';
   }
 
   if (!isxdigit(static_cast<unsigned char>(CurPtr[0]))) {
     // Bad token, return it as an error.
-    CurPtr = TokStart+1;
+    advancePositionTo(TokStart + 1);
     return lltok::Error;
   }
 
   while (isxdigit(static_cast<unsigned char>(CurPtr[0])))
-    ++CurPtr;
+    getNextChar();
 
   if (Kind == 'J') {
     // HexFPConstant - Floating point constant represented in IEEE format as a
@@ -1152,7 +1172,7 @@ lltok::Kind LLLexer::LexDigitOrNegative() {
     // Okay, this is not a number after the -, it's probably a label.
     if (const char *End = isLabelTail(CurPtr)) {
       StrVal.assign(TokStart, End-1);
-      CurPtr = End;
+      advancePositionTo(End);
       return lltok::LabelStr;
     }
 
@@ -1162,13 +1182,13 @@ lltok::Kind LLLexer::LexDigitOrNegative() {
   // At this point, it is either a label, int or fp constant.
 
   // Skip digits, we have at least one.
-  for (; isdigit(static_cast<unsigned char>(CurPtr[0])); ++CurPtr)
+  for (; isdigit(static_cast<unsigned char>(CurPtr[0])); getNextChar())
     /*empty*/;
 
   // Check if this is a fully-numeric label:
   if (isdigit(TokStart[0]) && CurPtr[0] == ':') {
     uint64_t Val = atoull(TokStart, CurPtr);
-    ++CurPtr; // Skip the colon.
+    getNextChar(); // Skip the colon.
     if ((unsigned)Val != Val)
       LexError("invalid value number (too large)");
     UIntVal = unsigned(Val);
@@ -1179,7 +1199,7 @@ lltok::Kind LLLexer::LexDigitOrNegative() {
   if (isLabelChar(CurPtr[0]) || CurPtr[0] == ':') {
     if (const char *End = isLabelTail(CurPtr)) {
       StrVal.assign(TokStart, End-1);
-      CurPtr = End;
+      advancePositionTo(End);
       return lltok::LabelStr;
     }
   }
@@ -1193,17 +1213,19 @@ lltok::Kind LLLexer::LexDigitOrNegative() {
     return lltok::APSInt;
   }
 
-  ++CurPtr;
+  getNextChar();
 
   // Skip over [0-9]*([eE][-+]?[0-9]+)?
-  while (isdigit(static_cast<unsigned char>(CurPtr[0]))) ++CurPtr;
+  while (isdigit(static_cast<unsigned char>(CurPtr[0])))
+    getNextChar();
 
   if (CurPtr[0] == 'e' || CurPtr[0] == 'E') {
     if (isdigit(static_cast<unsigned char>(CurPtr[1])) ||
         ((CurPtr[1] == '-' || CurPtr[1] == '+') &&
           isdigit(static_cast<unsigned char>(CurPtr[2])))) {
-      CurPtr += 2;
-      while (isdigit(static_cast<unsigned char>(CurPtr[0]))) ++CurPtr;
+      skipNChars(2);
+      while (isdigit(static_cast<unsigned char>(CurPtr[0])))
+        getNextChar();
     }
   }
 
@@ -1221,26 +1243,29 @@ lltok::Kind LLLexer::LexPositive() {
     return lltok::Error;
 
   // Skip digits.
-  for (++CurPtr; isdigit(static_cast<unsigned char>(CurPtr[0])); ++CurPtr)
+  for (getNextChar(); isdigit(static_cast<unsigned char>(CurPtr[0]));
+       getNextChar())
     /*empty*/;
 
   // At this point, we need a '.'.
   if (CurPtr[0] != '.') {
-    CurPtr = TokStart+1;
+    advancePositionTo(TokStart + 1);
     return lltok::Error;
   }
 
-  ++CurPtr;
+  getNextChar();
 
   // Skip over [0-9]*([eE][-+]?[0-9]+)?
-  while (isdigit(static_cast<unsigned char>(CurPtr[0]))) ++CurPtr;
+  while (isdigit(static_cast<unsigned char>(CurPtr[0])))
+    getNextChar();
 
   if (CurPtr[0] == 'e' || CurPtr[0] == 'E') {
     if (isdigit(static_cast<unsigned char>(CurPtr[1])) ||
         ((CurPtr[1] == '-' || CurPtr[1] == '+') &&
         isdigit(static_cast<unsigned char>(CurPtr[2])))) {
-      CurPtr += 2;
-      while (isdigit(static_cast<unsigned char>(CurPtr[0]))) ++CurPtr;
+      skipNChars(2);
+      while (isdigit(static_cast<unsigned char>(CurPtr[0])))
+        getNextChar();
     }
   }
 

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -176,7 +176,7 @@ LLLexer::LLLexer(StringRef StartBuf, SourceMgr &SM, SMDiagnostic &Err,
 
 int LLLexer::getNextChar() {
   char CurChar = *CurPtr++;
-  if (CurChar == '\n') {
+  if ((CurPtr - 2) >= CurBuf.begin() && *(CurPtr - 2) == '\n') {
     CurLineNum++;
     CurColNum = 0;
   } else
@@ -216,8 +216,10 @@ void LLLexer::advancePositionTo(const char *Ptr) {
 lltok::Kind LLLexer::LexToken() {
   while (true) {
     TokStart = CurPtr;
-
     int CurChar = getNextChar();
+    CurTokColNum = CurColNum;
+    CurTokLineNum = CurLineNum;
+
     switch (CurChar) {
     default:
       // Handle letters: [a-zA-Z_]

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -229,6 +229,15 @@ void LLLexer::advancePositionTo(const char *Ptr) {
 }
 
 lltok::Kind LLLexer::LexToken() {
+  // Set token end to next location, since the end is
+  // exclusive
+  if (CurPtr != CurBuf.begin() && *(CurPtr - 1) == '\n') {
+    PrevTokEndLineNum = CurLineNum + 1;
+    PrevTokEndColNum = 0;
+  } else {
+    PrevTokEndLineNum = CurLineNum;
+    PrevTokEndColNum = CurColNum + 1;
+  }
   while (true) {
     TokStart = CurPtr;
     int CurChar = getNextChar();

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -217,7 +217,7 @@ void LLLexer::advancePositionTo(const char *Ptr) {
   }
   if (RecalculateColumn) {
     CurColNum = 0;
-    for (const char *Ptr = CurPtr; Ptr != CurBuf.begin() || *(Ptr - 1) != '\n';
+    for (const char *Ptr = CurPtr; Ptr != CurBuf.begin() && *(Ptr - 1) != '\n';
          --Ptr, ++CurColNum)
       ;
   }

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -744,7 +744,7 @@ bool LLParser::parseDeclare() {
 ///   ::= 'define' FunctionHeader (!dbg !56)* '{' ...
 bool LLParser::parseDefine() {
   assert(Lex.getKind() == lltok::kw_define);
-  FileLoc FunctionStart(Lex.getLineNum(), Lex.getColNum());
+  FileLoc FunctionStart(Lex.getTokLineNum(), Lex.getTokColNum());
   Lex.Lex();
 
   Function *F;
@@ -756,7 +756,8 @@ bool LLParser::parseDefine() {
       parseFunctionBody(*F, FunctionNumber, UnnamedArgNums);
   if (ParserContext)
     ParserContext->addFunctionLocation(
-        F, FileLocRange(FunctionStart, {Lex.getLineNum(), Lex.getColNum()}));
+        F, FileLocRange(FunctionStart, {Lex.getPrevTokEndLineNum(),
+                                        Lex.getPrevTokEndColNum()}));
 
   return RetValue;
 }
@@ -6883,7 +6884,7 @@ bool LLParser::parseFunctionBody(Function &Fn, unsigned FunctionNumber,
 /// parseBasicBlock
 ///   ::= (LabelStr|LabelID)? Instruction*
 bool LLParser::parseBasicBlock(PerFunctionState &PFS) {
-  FileLoc BBStart(Lex.getLineNum(), Lex.getColNum()-1);
+  FileLoc BBStart(Lex.getTokLineNum(), Lex.getTokColNum());
 
   // If this basic block starts out with a name, remember it.
   std::string Name;
@@ -6928,7 +6929,7 @@ bool LLParser::parseBasicBlock(PerFunctionState &PFS) {
       TrailingDbgRecord.emplace_back(DR, DeleteDbgRecord);
     }
 
-    FileLoc InstStart(Lex.getLineNum(), Lex.getColNum()-1);
+    FileLoc InstStart(Lex.getTokLineNum(), Lex.getTokColNum());
     // This instruction may have three possibilities for a name: a) none
     // specified, b) name specified "%foo =", c) number specified: "%4 =".
     LocTy NameLoc = Lex.getLoc();
@@ -6978,15 +6979,17 @@ bool LLParser::parseBasicBlock(PerFunctionState &PFS) {
     for (DbgRecordPtr &DR : TrailingDbgRecord)
       BB->insertDbgRecordBefore(DR.release(), Inst->getIterator());
     TrailingDbgRecord.clear();
-    if (ParserContext)
+    if (ParserContext) {
       ParserContext->addInstructionLocation(
-          Inst,
-          FileLocRange(InstStart, {Lex.getLineNum(), Lex.getColNum() - 1}));
+          Inst, FileLocRange(InstStart, {Lex.getPrevTokEndLineNum(),
+                                         Lex.getPrevTokEndColNum()}));
+    }
   } while (!Inst->isTerminator());
 
   if (ParserContext)
     ParserContext->addBlockLocation(
-        BB, FileLocRange(BBStart, {Lex.getLineNum(), Lex.getColNum() - 1}));
+        BB, FileLocRange(BBStart, {Lex.getPrevTokEndLineNum(),
+                                   Lex.getPrevTokEndColNum()}));
 
   assert(TrailingDbgRecord.empty() &&
          "All debug values should have been attached to an instruction.");

--- a/llvm/unittests/AsmParser/AsmParserTest.cpp
+++ b/llvm/unittests/AsmParser/AsmParserTest.cpp
@@ -483,7 +483,21 @@ TEST(AsmParserTest, DIExpressionBodyAtBeginningWithSlotMappingParsing) {
   ASSERT_EQ(Mapping.MetadataNodes.size(), 0u);
 }
 
-TEST(AsmParserTest, DISABLED_ParserObjectLocations) {
+#define ASSERT_EQ_LOC(Loc1, Loc2)                                              \
+  do {                                                                         \
+    bool AreLocsEqual = Loc1.contains(Loc2) && Loc2.contains(Loc1);            \
+    if (!AreLocsEqual) {                                                       \
+      dbgs() << #Loc1 " location: " << Loc1.Start.Line << ":"                  \
+             << Loc1.Start.Col << " - " << Loc1.End.Line << ":"                \
+             << Loc1.End.Col << "\n";                                          \
+      dbgs() << #Loc2 " location: " << Loc2.Start.Line << ":"                  \
+             << Loc2.Start.Col << " - " << Loc2.End.Line << ":"                \
+             << Loc2.End.Col << "\n";                                          \
+    }                                                                          \
+    ASSERT_TRUE(AreLocsEqual);                                                 \
+  } while (false)
+
+TEST(AsmParserTest, ParserObjectLocations) {
   // Expected to fail with function location starting one character later, needs
   // a fix
   StringRef Source = "define i32 @main() {\n"
@@ -503,26 +517,25 @@ TEST(AsmParserTest, DISABLED_ParserObjectLocations) {
   auto MaybeMainLoc = ParserContext.getFunctionLocation(MainFn);
   ASSERT_TRUE(MaybeMainLoc.has_value());
   auto MainLoc = MaybeMainLoc.value();
-  ASSERT_TRUE(MainLoc.contains(FileLocRange(FileLoc{0, 0}, FileLoc{4, 1})));
-  ASSERT_TRUE(FileLocRange(FileLoc{0, 0}, FileLoc{4, 1}).contains(MainLoc));
+  auto ExpectedMainLoc = FileLocRange(FileLoc{0, 0}, FileLoc{4, 1});
+  ASSERT_EQ_LOC(MainLoc, ExpectedMainLoc);
 
   auto &EntryBB = MainFn->getEntryBlock();
   auto MaybeEntryBBLoc = ParserContext.getBlockLocation(&EntryBB);
   ASSERT_TRUE(MaybeEntryBBLoc.has_value());
   auto EntryBBLoc = MaybeEntryBBLoc.value();
-  ASSERT_TRUE(EntryBBLoc.contains(FileLocRange(FileLoc{1, 0}, FileLoc{4, 0})));
-  ASSERT_TRUE(FileLocRange(FileLoc{1, 0}, FileLoc{4, 0}).contains(EntryBBLoc));
+  auto ExpectedEntryBBLoc = FileLocRange(FileLoc{1, 0}, FileLoc{3, 14});
+  ASSERT_EQ_LOC(EntryBBLoc, ExpectedEntryBBLoc);
 
   SmallVector<FileLocRange> InstructionLocations = {
-      FileLocRange(FileLoc{2, 4}, FileLoc{3, 4}),
-      FileLocRange(FileLoc{3, 4}, FileLoc{4, 0})};
+      FileLocRange(FileLoc{2, 4}, FileLoc{2, 21}),
+      FileLocRange(FileLoc{3, 4}, FileLoc{3, 14})};
 
-  for (const auto &[Inst, Loc] : zip(EntryBB, InstructionLocations)) {
+  for (const auto &[Inst, ExpectedLoc] : zip(EntryBB, InstructionLocations)) {
     auto MaybeInstLoc = ParserContext.getInstructionLocation(&Inst);
     ASSERT_TRUE(MaybeMainLoc.has_value());
     auto InstLoc = MaybeInstLoc.value();
-    ASSERT_TRUE(InstLoc.contains(Loc));
-    ASSERT_TRUE(Loc.contains(InstLoc));
+    ASSERT_EQ_LOC(InstLoc, ExpectedLoc);
   }
 }
 


### PR DESCRIPTION
Fixes tracking of location in source and keeps track of current token start and prev token end, and uses it for accurate location tracking of functions, basic blocks and instructions.

Updates the test that checks this functionality with a convenience macro and more precise expected locations.