### PR TITLE
Use external opt

### DIFF
--- a/llvm/tools/llvm-lsp/IRDocument.h
+++ b/llvm/tools/llvm-lsp/IRDocument.h
@@ -176,14 +176,13 @@ public:
     }
   }
 
-  std::optional<std::string> getIRBeforePassNumber(unsigned N) {
+  std::optional<std::filesystem::path> getIRBeforePassNumber(unsigned N) {
     if (!IntermediateIRDirectories.contains(N) ||
-        !std::filesystem::exists(IntermediateIRDirectories[N].string() +
-                                 "/ir.ll")) {
+        !std::filesystem::exists(IntermediateIRDirectories[N] / IrLLFilename)) {
       lsp::Logger::info("Did not find IR!");
       return std::nullopt;
     }
-    return IntermediateIRDirectories[N].string() + "/ir.ll";
+    return IntermediateIRDirectories[N] / IrLLFilename;
   }
 
   std::optional<std::string> getDotFilePath(Function *F) {

--- a/llvm/tools/llvm-lsp/IRDocument.h
+++ b/llvm/tools/llvm-lsp/IRDocument.h
@@ -32,6 +32,8 @@
 
 namespace {
 
+constexpr const char *IrLLFilename = "ir.ll";
+
 class IRDocumentHelpers {
 public:
   static std::optional<std::string>
@@ -148,7 +150,7 @@ public:
     if (!std::filesystem::exists(IRFolder))
       std::filesystem::create_directory(IRFolder);
     IntermediateIRDirectories[PassNum] = IRFolder;
-    return IRFolder / "ir.ll";
+    return IRFolder / IrLLFilename;
   }
 
   void addIntermediateIR(Module &M, unsigned PassNum, StringRef PassName) {
@@ -159,7 +161,7 @@ public:
     IntermediateIRDirectories[PassNum] = IRFolder;
     lsp::Logger::info("Created directory for intermediate IR artifacts!");
 
-    auto IRFilepath = IRFolder / "ir.ll";
+    auto IRFilepath = IRFolder / IrLLFilename;
     if (!std::filesystem::exists(IRFilepath)) {
       lsp::Logger::info("Creating new file to store Intermediate IR: {}",
                         IRFilepath.string());

--- a/llvm/tools/llvm-lsp/IRDocument.h
+++ b/llvm/tools/llvm-lsp/IRDocument.h
@@ -141,6 +141,16 @@ public:
     DotFileList[F] = DotFilePath;
   }
 
+  std::filesystem::path getIntermediateIRPath(unsigned PassNum,
+                                              StringRef PassName) {
+    auto IRFolder =
+        ArtifactsFolderPath / (std::to_string(PassNum) + "-" + PassName.str());
+    if (!std::filesystem::exists(IRFolder))
+      std::filesystem::create_directory(IRFolder);
+    IntermediateIRDirectories[PassNum] = IRFolder;
+    return IRFolder / "ir.ll";
+  }
+
   void addIntermediateIR(Module &M, unsigned PassNum, StringRef PassName) {
     auto IRFolder =
         ArtifactsFolderPath / (std::to_string(PassNum) + "-" + PassName.str());
@@ -165,8 +175,10 @@ public:
   }
 
   std::optional<std::string> getIRBeforePassNumber(unsigned N) {
-    if (!IntermediateIRDirectories.contains(N)) {
-      lsp::Logger::info("Did not find IR Directory!");
+    if (!IntermediateIRDirectories.contains(N) ||
+        !std::filesystem::exists(IntermediateIRDirectories[N].string() +
+                                 "/ir.ll")) {
+      lsp::Logger::info("Did not find IR!");
       return std::nullopt;
     }
     return IntermediateIRDirectories[N].string() + "/ir.ll";
@@ -286,15 +298,14 @@ public:
     lsp::Logger::info("Found Pass name for pass number {} as {}",
                       std::to_string(N), PassName);
 
-    auto IntermediateIR = Optimizer->getModuleBeforePass(Pipeline, N);
+    auto ModulePath = IRA->getIntermediateIRPath(N, PassName);
+
+    auto IntermediateIR =
+        Optimizer->getModuleBeforePass(Pipeline, N, StringRef(ModulePath));
     if (!IntermediateIR) {
       lsp::Logger::info("Error while getting intermediate IR");
       return IntermediateIR.takeError();
     }
-    lsp::Logger::info(
-        "Got intermediate IR. Storing it in Artifacts Directory!");
-    IRA->addIntermediateIR(*IntermediateIR.get(), N, PassName);
-    lsp::Logger::info("Finished storing in Artifacts directory!");
     return *IRA->getIRBeforePassNumber(N);
   }
 

--- a/llvm/tools/llvm-lsp/IRDocument.h
+++ b/llvm/tools/llvm-lsp/IRDocument.h
@@ -213,10 +213,12 @@ class IRDocument {
   std::unique_ptr<IRArtifacts> IRA;
 
 public:
-  IRDocument(const std::string &PathToIRFile) : Filepath(PathToIRFile) {
+  IRDocument(const std::string &PathToIRFile,
+             std::optional<std::string> OptPath = std::nullopt)
+      : Filepath(PathToIRFile) {
     ParsedModule = loadModuleFromIR(PathToIRFile, C);
     IRA = std::make_unique<IRArtifacts>(Filepath, *ParsedModule);
-    Optimizer = std::make_unique<OptRunner>(*ParsedModule, Filepath);
+    Optimizer = std::make_unique<OptRunner>(*ParsedModule, Filepath, OptPath);
 
     // Eagerly generate all CFG for all functions in the IRDocument.
     IRA->generateGraphs(ParserContext);

--- a/llvm/tools/llvm-lsp/IRDocument.h
+++ b/llvm/tools/llvm-lsp/IRDocument.h
@@ -164,7 +164,7 @@ public:
     }
   }
 
-  std::optional<std::string> getIRAfterPassNumber(unsigned N) {
+  std::optional<std::string> getIRBeforePassNumber(unsigned N) {
     if (!IntermediateIRDirectories.contains(N)) {
       lsp::Logger::info("Did not find IR Directory!");
       return std::nullopt;
@@ -268,10 +268,11 @@ public:
     return nullptr;
   }
 
+  // This ↓ doesn't seem to be true
   // N is 1-Indexed here, but IRA expects 0-Indexed
-  llvm::Expected<std::string> getIRAfterPassNumber(const std::string &Pipeline,
-                                                   unsigned N) {
-    auto ExistingIR = IRA->getIRAfterPassNumber(N);
+  llvm::Expected<std::string> getIRBeforePassNumber(const std::string &Pipeline,
+                                                    unsigned N, ArrayRef<StringRef> AdditionalOptArgs = {}) {
+    auto ExistingIR = IRA->getIRBeforePassNumber(N);
     if (ExistingIR) {
       lsp::Logger::info("Found Existing IR");
       return *ExistingIR;
@@ -283,7 +284,7 @@ public:
     lsp::Logger::info("Found Pass name for pass number {} as {}",
                       std::to_string(N), PassName);
 
-    auto IntermediateIR = Optimizer->getModuleAfterPass(Pipeline, N);
+    auto IntermediateIR = Optimizer->getModuleBeforePass(Pipeline, N);
     if (!IntermediateIR) {
       lsp::Logger::info("Error while getting intermediate IR");
       return IntermediateIR.takeError();
@@ -292,7 +293,7 @@ public:
         "Got intermediate IR. Storing it in Artifacts Directory!");
     IRA->addIntermediateIR(*IntermediateIR.get(), N, PassName);
     lsp::Logger::info("Finished storing in Artifacts directory!");
-    return *IRA->getIRAfterPassNumber(N);
+    return *IRA->getIRBeforePassNumber(N);
   }
 
   // FIXME: We are doing some redundant work here in below functions, which can

--- a/llvm/tools/llvm-lsp/IRDocument.h
+++ b/llvm/tools/llvm-lsp/IRDocument.h
@@ -207,21 +207,20 @@ private:
 class IRDocument {
   LLVMContext C;
   std::unique_ptr<Module> ParsedModule;
-  StringRef Filepath;
+  std::string Filepath;
 
   std::unique_ptr<OptRunner> Optimizer;
   std::unique_ptr<IRArtifacts> IRA;
 
 public:
-  IRDocument(StringRef PathToIRFile) : Filepath(PathToIRFile) {
+  IRDocument(const std::string &PathToIRFile) : Filepath(PathToIRFile) {
     ParsedModule = loadModuleFromIR(PathToIRFile, C);
-    IRA = std::make_unique<IRArtifacts>(PathToIRFile, *ParsedModule);
-    Optimizer = std::make_unique<OptRunner>(*ParsedModule);
+    IRA = std::make_unique<IRArtifacts>(Filepath, *ParsedModule);
+    Optimizer = std::make_unique<OptRunner>(*ParsedModule, Filepath);
 
     // Eagerly generate all CFG for all functions in the IRDocument.
     IRA->generateGraphs(ParserContext);
-    lsp::Logger::info("Finished setting up IR Document: {}",
-                      PathToIRFile.str());
+    lsp::Logger::info("Finished setting up IR Document: {}", PathToIRFile);
   }
 
   // ---------------- APIs that the Language Server can use  -----------------

--- a/llvm/tools/llvm-lsp/OptRunner.h
+++ b/llvm/tools/llvm-lsp/OptRunner.h
@@ -91,12 +91,12 @@ public:
   llvm::Expected<SmallVector<std::pair<std::string, std::string>, 256>>
   getPassListAndDescription(const std::string PipelineText) {
     // First is Passname, Second is Pass Description.
-    auto MaybeOutErr = runShellOpt(
-        {"--print-pass-numbers", "--passes", PipelineText, "--disable-output"});
+    auto MaybeOutErr =
+        runShellOpt({"-S", "--print-pass-numbers", "--passes", PipelineText});
     if (!MaybeOutErr)
       return MaybeOutErr.takeError();
     auto [_, Stderr] = *MaybeOutErr;
-    SmallString<256> StderrContent;
+    SmallString<1024> StderrContent;
     auto MaybeStderrFD = llvm::sys::fs::openNativeFileForRead(Stderr);
     if (!MaybeStderrFD) {
       lsp::Logger::error("Can't open error file from opt.");
@@ -110,17 +110,28 @@ public:
 
     SmallVector<std::pair<std::string, std::string>, 256>
         PassListAndDescription;
-    lsp::Logger::debug("Starting to parse {}", StderrContent);
-    auto [LHS, RHS] = StringRef(StderrContent).split('\n');
-    while (LHS != StderrContent) {
-      lsp::Logger::debug("Parsing line {}", LHS);
-      auto NumberPlus = LHS.drop_while([](char C) { return !isDigit(C); });
+    // lsp::Logger::debug("Starting to parse {}", StderrContent);
+    StringRef ContentRef = StderrContent;
+    int Iteration = 0;
+    while (!(ContentRef.empty() || ContentRef == "\n") && Iteration <= 150) {
+      ++Iteration;
+      // lsp::Logger::debug("Parsing line {}", ContentRef);
+      auto NumberPlus =
+          ContentRef.drop_while([](char C) { return !isDigit(C); });
+      // lsp::Logger::debug("Number found. {}", NumberPlus);
       auto Number = NumberPlus.take_while(isDigit);
-      auto AfterNumber =
-          LHS.drop_while([](char C) { return isDigit(C) || isSpace(C); });
+      // lsp::Logger::debug("Number isolated. {}", Number);
+      auto AfterNumber = NumberPlus.drop_while(
+          [](char C) { return isDigit(C) || isSpace(C); });
+      auto Description =
+          AfterNumber.take_while([](char C) { return C != '\n'; });
+      auto Next = AfterNumber.drop_while([](char C) { return C != '\n'; });
+      // lsp::Logger::debug("Rest isolated. {}", AfterNumber);
 
-      PassListAndDescription.emplace_back(Number.str(), AfterNumber.str());
-      StderrContent = RHS;
+      PassListAndDescription.emplace_back(Number.str(), Description.str());
+      // lsp::Logger::debug("Emplaced");
+      ContentRef = Next;
+      // lsp::Logger::debug("Reset");
     }
     return PassListAndDescription;
   }
@@ -173,11 +184,11 @@ public:
     auto OptStr = *Opt;
     SmallString<32> /*std::string*/ Stdout; // = "/tmp/stderr";
     SmallString<32> /*std::string*/ Stderr; // = "/tmp/stdout";
-    llvm::sys::fs::createTemporaryFile("llvm-lsp-stdout", "ll", Stdout);
-    llvm::sys::fs::createTemporaryFile("llvm-lsp-stderr", "ll", Stderr);
+    // llvm::sys::fs::createTemporaryFile("llvm-lsp-stdout", "ll", Stdout);
+    // llvm::sys::fs::createTemporaryFile("llvm-lsp-stderr", "ll", Stderr);
 
-    // llvm::sys::fs::createUniquePath("llvm-lsp-stdout-%.ll", Stdout, true);
-    // llvm::sys::fs::createUniquePath("llvm-lsp-stderr-%.ll", Stderr, true);
+    llvm::sys::fs::createUniquePath("llvm-lsp-stdout-%.ll", Stdout, true);
+    llvm::sys::fs::createUniquePath("llvm-lsp-stderr-%.ll", Stderr, true);
 
     std::optional<StringRef> Redirects[] = {std::nullopt, StringRef(Stdout),
                                             StringRef(Stderr)};
@@ -202,7 +213,10 @@ public:
 
     auto ExitCode =
         llvm::sys::ExecuteAndWait(OptStr, AllArgs, std::nullopt, Redirects);
-    lsp::Logger::debug("Opt run done");
+    llvm::sys::fs::file_status S;
+    llvm::sys::fs::status(Stderr, S);
+    lsp::Logger::debug("stderr size: {}", S.getSize());
+    lsp::Logger::debug("Opt run done. ExitCode: {}", ExitCode);
     if (ExitCode) {
       SmallString<128> StderrContent;
       auto MaybeStderrFD = llvm::sys::fs::openNativeFileForRead(Stderr);

--- a/llvm/tools/llvm-lsp/OptRunner.h
+++ b/llvm/tools/llvm-lsp/OptRunner.h
@@ -190,6 +190,9 @@ public:
     llvm::sys::fs::createUniquePath("llvm-lsp-stdout-%.ll", Stdout, true);
     llvm::sys::fs::createUniquePath("llvm-lsp-stderr-%.ll", Stderr, true);
 
+    llvm::sys::fs::remove(Stdout);
+    llvm::sys::fs::remove(Stderr);
+
     std::optional<StringRef> Redirects[] = {std::nullopt, StringRef(Stdout),
                                             StringRef(Stderr)};
     // std::optional<StringRef> Redirects[] = {std::nullopt, std::nullopt,

--- a/llvm/tools/llvm-lsp/OptRunner.h
+++ b/llvm/tools/llvm-lsp/OptRunner.h
@@ -11,6 +11,7 @@
 
 #include "Protocol.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/IR/Function.h"
@@ -35,7 +36,7 @@ class OptRunner {
   LLVMContext Context;
   const Module &InitialIR;
   const StringRef File;
-  const std::optional<std::string> OptPath;
+  const std::optional<std::string> OptPath = std::nullopt;
 
   SmallVector<std::unique_ptr<Module>, 256> IntermediateIRList;
 
@@ -179,23 +180,33 @@ public:
   }
 
   llvm::Expected<std::pair<SmallString<32>, SmallString<32>>>
-  runShellOpt(std::vector<std::string> Args) {
+  runShellOpt(std::vector<std::string> Args,
+              std::optional<StringRef> Stdout = std::nullopt,
+              std::optional<StringRef> Stderr = std::nullopt) {
     std::string OptStr;
     if (OptPath) {
+      lsp::Logger::debug("Using provided opt path: {}", OptPath.value());
       OptStr = OptPath.value();
     } else {
+      lsp::Logger::debug("Searching for opt in PATH");
       auto Opt = llvm::sys::findProgramByName("opt");
       if (!Opt)
         return llvm::make_error<StringError>(Opt.getError(), "opt not found");
+      OptStr = *Opt;
     }
 
-    SmallString<32> Stdout;
-    SmallString<32> Stderr;
-    llvm::sys::fs::createTemporaryFile("llvm-lsp-stdout", "ll", Stdout);
-    llvm::sys::fs::createTemporaryFile("llvm-lsp-stderr", "ll", Stderr);
+    SmallString<32> StdoutStr;
+    if (!Stdout.has_value()) {
+      llvm::sys::fs::createTemporaryFile("llvm-lsp-stdout", "ll", StdoutStr);
+      Stdout = StdoutStr;
+    }
+    SmallString<32> StderrStr;
+    if (!Stderr.has_value()) {
+      llvm::sys::fs::createTemporaryFile("llvm-lsp-stderr", "ll", StderrStr);
+      Stderr = StderrStr;
+    }
 
-    std::optional<StringRef> Redirects[] = {std::nullopt, StringRef(Stdout),
-                                            StringRef(Stderr)};
+    std::optional<StringRef> Redirects[] = {std::nullopt, Stdout, Stderr};
 
     std::vector<StringRef> AllArgs;
     for (const auto &Arg : Args)
@@ -216,12 +227,12 @@ public:
     auto ExitCode =
         llvm::sys::ExecuteAndWait(OptStr, AllArgs, std::nullopt, Redirects);
     llvm::sys::fs::file_status S;
-    llvm::sys::fs::status(Stderr, S);
+    llvm::sys::fs::status(*Stderr, S);
     lsp::Logger::debug("stderr size: {}", S.getSize());
     lsp::Logger::debug("Opt run done. ExitCode: {}", ExitCode);
     if (ExitCode) {
       SmallString<128> StderrContent;
-      auto MaybeStderrFD = llvm::sys::fs::openNativeFileForRead(Stderr);
+      auto MaybeStderrFD = llvm::sys::fs::openNativeFileForRead(*Stderr);
       if (!MaybeStderrFD) {
         lsp::Logger::error("Can't open error file from opt.");
         return MaybeStderrFD.takeError();
@@ -232,18 +243,22 @@ public:
         lsp::Logger::error("Can't open error file from opt.");
         return Res;
       }
-      lsp::Logger::error("Opt error: {}", StderrContent);
-      return llvm::createStringError("Running opt failed.");
+      lsp::Logger::error("Opt error: Exit code: {}, Stderr: {}", ExitCode,
+                         StderrContent);
+      return llvm::createStringError(
+          "Running opt failed. Exit code: %d, Stderr: %s", ExitCode,
+          StderrContent.c_str());
     }
     lsp::Logger::debug("Opt run handle done");
-    return std::make_pair(Stdout, Stderr);
+    return std::make_pair(*Stdout, *Stderr);
   }
 
   // TODO: Check if N lies with in bounds for below methods. And to verify that
   // they are populated.
   // N is 1-Indexed
-  llvm::Expected<std::unique_ptr<Module>>
+  llvm::Expected<StringRef>
   getModuleBeforePass(const std::string PipelineText, unsigned N,
+                      StringRef Path,
                       const ArrayRef<StringRef> AdditionalOptArgs = {}) {
 
     std::vector<std::string> Args = {"-S", "--print-before-pass-number",
@@ -251,14 +266,13 @@ public:
                                      PipelineText};
     for (const auto &Arg : AdditionalOptArgs)
       Args.emplace_back(Arg);
-    auto MaybeOutErr = runShellOpt(Args);
+    auto MaybeOutErr = runShellOpt(Args, std::nullopt, Path);
     if (!MaybeOutErr)
       return MaybeOutErr.takeError();
     auto [_, Stderr] = *MaybeOutErr;
 
-    SMDiagnostic Err;
     // Try to parse as textual IR
-    return parseIRFile(Stderr, Err, InitialIR.getContext());
+    return Stderr;
   }
 
   llvm::Expected<std::unique_ptr<Module>>

--- a/llvm/tools/llvm-lsp/OptRunner.h
+++ b/llvm/tools/llvm-lsp/OptRunner.h
@@ -236,10 +236,15 @@ public:
   // they are populated.
   // N is 1-Indexed
   llvm::Expected<std::unique_ptr<Module>>
-  getModuleAfterPass(const std::string PipelineText, unsigned N) {
-    auto MaybeOutErr =
-        runShellOpt({"-S", "--print-before-pass-number", std::to_string(N),
-                     "--passes", PipelineText});
+  getModuleBeforePass(const std::string PipelineText, unsigned N,
+                      const ArrayRef<StringRef> AdditionalOptArgs = {}) {
+
+    std::vector<std::string> Args = {"-S", "--print-before-pass-number",
+                                     std::to_string(N), "--passes",
+                                     PipelineText};
+    for (const auto &Arg : AdditionalOptArgs)
+      Args.emplace_back(Arg);
+    auto MaybeOutErr = runShellOpt(Args);
     if (!MaybeOutErr)
       return MaybeOutErr.takeError();
     auto [_, Stderr] = *MaybeOutErr;
@@ -256,12 +261,14 @@ public:
     return runOpt(PipelineText, EmptyCallback);
   }
 
+  /// Get's name of N-th pass
+  /// N is 1 indexed
   llvm::Expected<std::string> getPassName(std::string PipelineText,
                                           unsigned N) {
     auto Passes = getPassListAndDescription(PipelineText);
     if (!Passes)
       return Passes.takeError();
-    return Passes->operator[](N).first;
+    return Passes->operator[](N - 1).first;
   }
 };
 

--- a/llvm/tools/llvm-lsp/OptRunner.h
+++ b/llvm/tools/llvm-lsp/OptRunner.h
@@ -31,6 +31,25 @@
 
 namespace llvm {
 
+SmallVector<std::pair<std::string, std::string>, 256>
+parseOptPassList(StringRef OptOutput) {
+  SmallVector<std::pair<std::string, std::string>, 256> PassListAndDescription;
+  int Iteration = 0;
+  while (!(OptOutput.empty() || OptOutput == "\n") && Iteration <= 150) {
+    ++Iteration;
+    auto NumberPlus = OptOutput.drop_while([](char C) { return !isDigit(C); });
+    auto Number = NumberPlus.take_while(isDigit);
+    auto AfterNumber =
+        NumberPlus.drop_while([](char C) { return isDigit(C) || isSpace(C); });
+    auto Description = AfterNumber.take_while([](char C) { return C != '\n'; });
+    auto Next = AfterNumber.drop_while([](char C) { return C != '\n'; });
+
+    PassListAndDescription.emplace_back(Number.str(), Description.str());
+    OptOutput = Next;
+  }
+  return PassListAndDescription;
+}
+
 // FIXME: Maybe a better name?
 class OptRunner {
   LLVMContext Context;
@@ -96,7 +115,8 @@ public:
   getPassListAndDescription(const std::string PipelineText) {
     // First is Passname, Second is Pass Description.
     auto MaybeOutErr =
-        runShellOpt({"-S", "--print-pass-numbers", "--passes", PipelineText});
+        runShellOpt({"-S", "--print-pass-numbers", "--disable-output",
+                     "--passes", PipelineText});
     if (!MaybeOutErr)
       return MaybeOutErr.takeError();
     auto [_, Stderr] = *MaybeOutErr;
@@ -111,33 +131,7 @@ public:
 
     if (Res)
       return Res;
-
-    SmallVector<std::pair<std::string, std::string>, 256>
-        PassListAndDescription;
-    // lsp::Logger::debug("Starting to parse {}", StderrContent);
-    StringRef ContentRef = StderrContent;
-    int Iteration = 0;
-    while (!(ContentRef.empty() || ContentRef == "\n") && Iteration <= 150) {
-      ++Iteration;
-      // lsp::Logger::debug("Parsing line {}", ContentRef);
-      auto NumberPlus =
-          ContentRef.drop_while([](char C) { return !isDigit(C); });
-      // lsp::Logger::debug("Number found. {}", NumberPlus);
-      auto Number = NumberPlus.take_while(isDigit);
-      // lsp::Logger::debug("Number isolated. {}", Number);
-      auto AfterNumber = NumberPlus.drop_while(
-          [](char C) { return isDigit(C) || isSpace(C); });
-      auto Description =
-          AfterNumber.take_while([](char C) { return C != '\n'; });
-      auto Next = AfterNumber.drop_while([](char C) { return C != '\n'; });
-      // lsp::Logger::debug("Rest isolated. {}", AfterNumber);
-
-      PassListAndDescription.emplace_back(Number.str(), Description.str());
-      // lsp::Logger::debug("Emplaced");
-      ContentRef = Next;
-      // lsp::Logger::debug("Reset");
-    }
-    return PassListAndDescription;
+    return parseOptPassList(StderrContent);
   }
 
   llvm::Expected<std::unique_ptr<Module>>
@@ -264,8 +258,11 @@ public:
                       StringRef Path,
                       const ArrayRef<StringRef> AdditionalOptArgs = {}) {
 
-    std::vector<std::string> Args = {"-S", "--print-before-pass-number",
-                                     std::to_string(N), "--passes",
+    std::vector<std::string> Args = {"-S",
+                                     "--disable-output",
+                                     "--print-before-pass-number",
+                                     std::to_string(N),
+                                     "--passes",
                                      PipelineText};
     for (const auto &Arg : AdditionalOptArgs)
       Args.emplace_back(Arg);

--- a/llvm/tools/llvm-lsp/OptRunner.h
+++ b/llvm/tools/llvm-lsp/OptRunner.h
@@ -182,21 +182,13 @@ public:
       return llvm::make_error<StringError>(Opt.getError(), "opt not found");
 
     auto OptStr = *Opt;
-    SmallString<32> /*std::string*/ Stdout; // = "/tmp/stderr";
-    SmallString<32> /*std::string*/ Stderr; // = "/tmp/stdout";
+    SmallString<32> Stdout;
+    SmallString<32> Stderr;
     llvm::sys::fs::createTemporaryFile("llvm-lsp-stdout", "ll", Stdout);
     llvm::sys::fs::createTemporaryFile("llvm-lsp-stderr", "ll", Stderr);
 
-    // llvm::sys::fs::createUniquePath("llvm-lsp-stdout-%.ll", Stdout, true);
-    // llvm::sys::fs::createUniquePath("llvm-lsp-stderr-%.ll", Stderr, true);
-
-    // llvm::sys::fs::remove(Stdout);
-    // llvm::sys::fs::remove(Stderr);
-
     std::optional<StringRef> Redirects[] = {std::nullopt, StringRef(Stdout),
                                             StringRef(Stderr)};
-    // std::optional<StringRef> Redirects[] = {std::nullopt, std::nullopt,
-    //                                         std::nullopt};
 
     std::vector<StringRef> AllArgs;
     for (const auto &Arg : Args)

--- a/llvm/tools/llvm-lsp/OptRunner.h
+++ b/llvm/tools/llvm-lsp/OptRunner.h
@@ -10,6 +10,8 @@
 #define LLVM_TOOLS_LLVM_LSP_OPTRUNNER_H
 
 #include "Protocol.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
@@ -17,8 +19,12 @@
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/LSP/Logging.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Program.h"
 #include "llvm/Transforms/Utils/Cloning.h"
+#include <algorithm>
 #include <memory>
 #include <string>
 
@@ -28,14 +34,15 @@ namespace llvm {
 class OptRunner {
   LLVMContext Context;
   const Module &InitialIR;
+  const StringRef File;
 
   SmallVector<std::unique_ptr<Module>, 256> IntermediateIRList;
 
 public:
-  OptRunner(Module &IIR) : InitialIR(IIR) {}
+  OptRunner(Module &IIR, StringRef File) : InitialIR(IIR), File(File) {}
 
   llvm::Expected<SmallVector<std::pair<std::string, std::string>, 256>>
-  getPassListAndDescription(const std::string PipelineText) {
+  getPassListAndDescriptionAPI(const std::string PipelineText) {
     // First is Passname, Second is Pass Description.
     SmallVector<std::pair<std::string, std::string>, 256>
         PassListAndDescription;
@@ -81,6 +88,42 @@ public:
     }
     return PassListAndDescription;
   }
+  llvm::Expected<SmallVector<std::pair<std::string, std::string>, 256>>
+  getPassListAndDescription(const std::string PipelineText) {
+    // First is Passname, Second is Pass Description.
+    auto MaybeOutErr = runShellOpt(
+        {"--print-pass-numbers", "--passes", PipelineText, "--disable-output"});
+    if (!MaybeOutErr)
+      return MaybeOutErr.takeError();
+    auto [_, Stderr] = *MaybeOutErr;
+    SmallString<256> StderrContent;
+    auto MaybeStderrFD = llvm::sys::fs::openNativeFileForRead(Stderr);
+    if (!MaybeStderrFD) {
+      lsp::Logger::error("Can't open error file from opt.");
+      return MaybeStderrFD.takeError();
+    }
+    auto Res =
+        llvm::sys::fs::readNativeFileToEOF(*MaybeStderrFD, StderrContent);
+
+    if (Res)
+      return Res;
+
+    SmallVector<std::pair<std::string, std::string>, 256>
+        PassListAndDescription;
+    lsp::Logger::debug("Starting to parse {}", StderrContent);
+    auto [LHS, RHS] = StringRef(StderrContent).split('\n');
+    while (LHS != StderrContent) {
+      lsp::Logger::debug("Parsing line {}", LHS);
+      auto NumberPlus = LHS.drop_while([](char C) { return !isDigit(C); });
+      auto Number = NumberPlus.take_while(isDigit);
+      auto AfterNumber =
+          LHS.drop_while([](char C) { return isDigit(C) || isSpace(C); });
+
+      PassListAndDescription.emplace_back(Number.str(), AfterNumber.str());
+      StderrContent = RHS;
+    }
+    return PassListAndDescription;
+  }
 
   llvm::Expected<std::unique_ptr<Module>>
   runOpt(const std::string PipelineText,
@@ -121,50 +164,80 @@ public:
     return FinalIR;
   }
 
+  llvm::Expected<std::pair<SmallString<32>, SmallString<32>>>
+  runShellOpt(std::vector<std::string> Args) {
+    auto Opt = llvm::sys::findProgramByName("opt");
+    if (!Opt)
+      return llvm::make_error<StringError>(Opt.getError(), "opt not found");
+
+    auto OptStr = *Opt;
+    SmallString<32> /*std::string*/ Stdout; // = "/tmp/stderr";
+    SmallString<32> /*std::string*/ Stderr; // = "/tmp/stdout";
+    llvm::sys::fs::createTemporaryFile("llvm-lsp-stdout", "ll", Stdout);
+    llvm::sys::fs::createTemporaryFile("llvm-lsp-stderr", "ll", Stderr);
+
+    // llvm::sys::fs::createUniquePath("llvm-lsp-stdout-%.ll", Stdout, true);
+    // llvm::sys::fs::createUniquePath("llvm-lsp-stderr-%.ll", Stderr, true);
+
+    std::optional<StringRef> Redirects[] = {std::nullopt, StringRef(Stdout),
+                                            StringRef(Stderr)};
+    // std::optional<StringRef> Redirects[] = {std::nullopt, std::nullopt,
+    //                                         std::nullopt};
+
+    std::vector<StringRef> AllArgs;
+    for (const auto &Arg : Args)
+      AllArgs.emplace_back(Arg);
+
+    AllArgs.emplace_back(File);
+
+    lsp::Logger::debug("Trying to run opt with these options:");
+    for (const auto &Arg : AllArgs) {
+      lsp::Logger::debug("{}", Arg);
+    }
+    lsp::Logger::debug("Shell command: {} {}", OptStr,
+                       llvm::join(AllArgs, " "));
+
+    lsp::Logger::debug("Output files:\n\tStdout: {}\n\tStderr: {}", Stdout,
+                       Stderr);
+
+    auto ExitCode =
+        llvm::sys::ExecuteAndWait(OptStr, AllArgs, std::nullopt, Redirects);
+    lsp::Logger::debug("Opt run done");
+    if (ExitCode) {
+      SmallString<128> StderrContent;
+      auto MaybeStderrFD = llvm::sys::fs::openNativeFileForRead(Stderr);
+      if (!MaybeStderrFD) {
+        lsp::Logger::error("Can't open error file from opt.");
+        return MaybeStderrFD.takeError();
+      }
+      auto Res =
+          llvm::sys::fs::readNativeFileToEOF(*MaybeStderrFD, StderrContent);
+      if (Res) {
+        lsp::Logger::error("Can't open error file from opt.");
+        return Res;
+      }
+      lsp::Logger::error("Opt error: {}", StderrContent);
+      return llvm::createStringError("Running opt failed.");
+    }
+    lsp::Logger::debug("Opt run handle done");
+    return std::make_pair(Stdout, Stderr);
+  }
+
   // TODO: Check if N lies with in bounds for below methods. And to verify that
   // they are populated.
   // N is 1-Indexed
   llvm::Expected<std::unique_ptr<Module>>
   getModuleAfterPass(const std::string PipelineText, unsigned N) {
-    unsigned PassNumber = 0;
-    std::unique_ptr<Module> IntermediateIR = nullptr;
-    std::function<void(const StringRef, Any, const PreservedAnalyses)>
-        RecordIRAfterPass = [&PassNumber, &N,
-                             &IntermediateIR](const StringRef PassName, Any IR,
-                                              const PreservedAnalyses &PA) {
-          PassNumber++;
-          if (PassNumber == N) {
-            IntermediateIR = [&IR, &PassName]() -> std::unique_ptr<Module> {
-              if (auto *M = any_cast<const Module *>(&IR))
-                return CloneModule(**M);
-              if (auto *F = any_cast<const Function *>(&IR))
-                return CloneModule(*(**F).getParent());
-              if (auto *L = any_cast<const Loop *>(&IR))
-                return CloneModule(
-                    *((*L)->getHeader()->getParent())->getParent());
-              if (auto *SCC = any_cast<const LazyCallGraph::SCC *>(&IR))
-                return CloneModule(
-                    *((**SCC).begin()->getFunction()).getParent());
+    auto MaybeOutErr =
+        runShellOpt({"-S", "--print-before-pass-number", std::to_string(N),
+                     "--passes", PipelineText});
+    if (!MaybeOutErr)
+      return MaybeOutErr.takeError();
+    auto [_, Stderr] = *MaybeOutErr;
 
-              lsp::Logger::error("Unknown Pass Type \"{}\"!", PassName.str());
-              return nullptr;
-            }();
-          }
-        };
-
-    auto RunOptResult = runOpt(PipelineText, RecordIRAfterPass);
-    if (!RunOptResult) {
-      return RunOptResult.takeError();
-    }
-
-    if (!IntermediateIR) {
-      lsp::Logger::error("Unrecognized Pass Number {}!", std::to_string(N));
-      return make_error<lsp::LSPError>(
-          formatv("Unrecognized pass number {}!", N),
-          lsp::ErrorCode::InvalidParams);
-    }
-
-    return IntermediateIR;
+    SMDiagnostic Err;
+    // Try to parse as textual IR
+    return parseIRFile(Stderr, Err, InitialIR.getContext());
   }
 
   llvm::Expected<std::unique_ptr<Module>>
@@ -176,30 +249,10 @@ public:
 
   llvm::Expected<std::string> getPassName(std::string PipelineText,
                                           unsigned N) {
-    unsigned PassNumber = 0;
-    std::string IntermediatePassName = "";
-    std::function<void(const StringRef, Any, const PreservedAnalyses)>
-        RecordNameAfterPass =
-            [&PassNumber, &N, &IntermediatePassName](
-                const StringRef PassName, Any IR, const PreservedAnalyses &PA) {
-              PassNumber++;
-              if (PassNumber == N)
-                IntermediatePassName = PassName.str();
-            };
-
-    auto RunOptResult = runOpt(PipelineText, RecordNameAfterPass);
-    if (!RunOptResult) {
-      return RunOptResult.takeError();
-    }
-
-    if (IntermediatePassName == "") {
-      lsp::Logger::error("Unrecognized Pass Number {}!", std::to_string(N));
-      return make_error<lsp::LSPError>(
-          formatv("Unrecognized pass number {}!", N),
-          lsp::ErrorCode::InvalidParams);
-    }
-
-    return IntermediatePassName;
+    auto Passes = getPassListAndDescription(PipelineText);
+    if (!Passes)
+      return Passes.takeError();
+    return Passes->operator[](N).first;
   }
 };
 

--- a/llvm/tools/llvm-lsp/OptRunner.h
+++ b/llvm/tools/llvm-lsp/OptRunner.h
@@ -184,14 +184,14 @@ public:
     auto OptStr = *Opt;
     SmallString<32> /*std::string*/ Stdout; // = "/tmp/stderr";
     SmallString<32> /*std::string*/ Stderr; // = "/tmp/stdout";
-    // llvm::sys::fs::createTemporaryFile("llvm-lsp-stdout", "ll", Stdout);
-    // llvm::sys::fs::createTemporaryFile("llvm-lsp-stderr", "ll", Stderr);
+    llvm::sys::fs::createTemporaryFile("llvm-lsp-stdout", "ll", Stdout);
+    llvm::sys::fs::createTemporaryFile("llvm-lsp-stderr", "ll", Stderr);
 
-    llvm::sys::fs::createUniquePath("llvm-lsp-stdout-%.ll", Stdout, true);
-    llvm::sys::fs::createUniquePath("llvm-lsp-stderr-%.ll", Stderr, true);
+    // llvm::sys::fs::createUniquePath("llvm-lsp-stdout-%.ll", Stdout, true);
+    // llvm::sys::fs::createUniquePath("llvm-lsp-stderr-%.ll", Stderr, true);
 
-    llvm::sys::fs::remove(Stdout);
-    llvm::sys::fs::remove(Stderr);
+    // llvm::sys::fs::remove(Stdout);
+    // llvm::sys::fs::remove(Stderr);
 
     std::optional<StringRef> Redirects[] = {std::nullopt, StringRef(Stdout),
                                             StringRef(Stderr)};

--- a/llvm/tools/llvm-lsp/OptRunner.h
+++ b/llvm/tools/llvm-lsp/OptRunner.h
@@ -35,11 +35,14 @@ class OptRunner {
   LLVMContext Context;
   const Module &InitialIR;
   const StringRef File;
+  const std::optional<std::string> OptPath;
 
   SmallVector<std::unique_ptr<Module>, 256> IntermediateIRList;
 
 public:
-  OptRunner(Module &IIR, StringRef File) : InitialIR(IIR), File(File) {}
+  OptRunner(Module &IIR, StringRef File,
+            std::optional<std::string> OptPath = std::nullopt)
+      : InitialIR(IIR), File(File), OptPath(OptPath) {}
 
   llvm::Expected<SmallVector<std::pair<std::string, std::string>, 256>>
   getPassListAndDescriptionAPI(const std::string PipelineText) {
@@ -177,11 +180,15 @@ public:
 
   llvm::Expected<std::pair<SmallString<32>, SmallString<32>>>
   runShellOpt(std::vector<std::string> Args) {
-    auto Opt = llvm::sys::findProgramByName("opt");
-    if (!Opt)
-      return llvm::make_error<StringError>(Opt.getError(), "opt not found");
+    std::string OptStr;
+    if (OptPath) {
+      OptStr = OptPath.value();
+    } else {
+      auto Opt = llvm::sys::findProgramByName("opt");
+      if (!Opt)
+        return llvm::make_error<StringError>(Opt.getError(), "opt not found");
+    }
 
-    auto OptStr = *Opt;
     SmallString<32> Stdout;
     SmallString<32> Stderr;
     llvm::sys::fs::createTemporaryFile("llvm-lsp-stdout", "ll", Stdout);

--- a/llvm/tools/llvm-lsp/OptRunner.h
+++ b/llvm/tools/llvm-lsp/OptRunner.h
@@ -181,8 +181,8 @@ public:
 
   llvm::Expected<std::pair<SmallString<32>, SmallString<32>>>
   runShellOpt(std::vector<std::string> Args,
-              std::optional<StringRef> Stdout = std::nullopt,
-              std::optional<StringRef> Stderr = std::nullopt) {
+              std::optional<StringRef> StdoutPath = std::nullopt,
+              std::optional<StringRef> StderrPath = std::nullopt) {
     std::string OptStr;
     if (OptPath) {
       lsp::Logger::debug("Using provided opt path: {}", OptPath.value());
@@ -195,18 +195,21 @@ public:
       OptStr = *Opt;
     }
 
-    SmallString<32> StdoutStr;
-    if (!Stdout.has_value()) {
-      llvm::sys::fs::createTemporaryFile("llvm-lsp-stdout", "ll", StdoutStr);
-      Stdout = StdoutStr;
+    SmallString<32> StdoutPathStr;
+    if (!StdoutPath.has_value()) {
+      llvm::sys::fs::createTemporaryFile("llvm-lsp-stdout", "ll",
+                                         StdoutPathStr);
+      StdoutPath = StdoutPathStr;
     }
-    SmallString<32> StderrStr;
-    if (!Stderr.has_value()) {
-      llvm::sys::fs::createTemporaryFile("llvm-lsp-stderr", "ll", StderrStr);
-      Stderr = StderrStr;
+    SmallString<32> StderrPathStr;
+    if (!StderrPath.has_value()) {
+      llvm::sys::fs::createTemporaryFile("llvm-lsp-stderr", "ll",
+                                         StderrPathStr);
+      StderrPath = StderrPathStr;
     }
 
-    std::optional<StringRef> Redirects[] = {std::nullopt, Stdout, Stderr};
+    std::optional<StringRef> Redirects[] = {std::nullopt, StdoutPath,
+                                            StderrPath};
 
     std::vector<StringRef> AllArgs;
     for (const auto &Arg : Args)
@@ -221,18 +224,18 @@ public:
     lsp::Logger::debug("Shell command: {} {}", OptStr,
                        llvm::join(AllArgs, " "));
 
-    lsp::Logger::debug("Output files:\n\tStdout: {}\n\tStderr: {}", Stdout,
-                       Stderr);
+    lsp::Logger::debug("Output files:\n\tStdout: {}\n\tStderr: {}", StdoutPath,
+                       StderrPath);
 
     auto ExitCode =
         llvm::sys::ExecuteAndWait(OptStr, AllArgs, std::nullopt, Redirects);
     llvm::sys::fs::file_status S;
-    llvm::sys::fs::status(*Stderr, S);
+    llvm::sys::fs::status(*StderrPath, S);
     lsp::Logger::debug("stderr size: {}", S.getSize());
     lsp::Logger::debug("Opt run done. ExitCode: {}", ExitCode);
     if (ExitCode) {
       SmallString<128> StderrContent;
-      auto MaybeStderrFD = llvm::sys::fs::openNativeFileForRead(*Stderr);
+      auto MaybeStderrFD = llvm::sys::fs::openNativeFileForRead(*StderrPath);
       if (!MaybeStderrFD) {
         lsp::Logger::error("Can't open error file from opt.");
         return MaybeStderrFD.takeError();
@@ -250,7 +253,7 @@ public:
           StderrContent.c_str());
     }
     lsp::Logger::debug("Opt run handle done");
-    return std::make_pair(*Stdout, *Stderr);
+    return std::make_pair(*StdoutPath, *StderrPath);
   }
 
   // TODO: Check if N lies with in bounds for below methods. And to verify that
@@ -269,10 +272,10 @@ public:
     auto MaybeOutErr = runShellOpt(Args, std::nullopt, Path);
     if (!MaybeOutErr)
       return MaybeOutErr.takeError();
-    auto [_, Stderr] = *MaybeOutErr;
+    auto [_, StderrPath] = *MaybeOutErr;
 
     // Try to parse as textual IR
-    return Stderr;
+    return StderrPath;
   }
 
   llvm::Expected<std::unique_ptr<Module>>

--- a/llvm/tools/llvm-lsp/Protocol.cpp
+++ b/llvm/tools/llvm-lsp/Protocol.cpp
@@ -47,7 +47,7 @@ llvm::json::Value llvm::lsp::toJSON(const PassList &Value) {
 }
 
 bool llvm::lsp::fromJSON(const llvm::json::Value &Value,
-                         GetIRAfterPassParams &Result, llvm::json::Path Path) {
+                         GetIRBeforePassParams &Result, llvm::json::Path Path) {
   llvm::json::ObjectMapper O(Value, Path);
   return O && O.map("uri", Result.uri) && O.map("pipeline", Result.pipeline) &&
          O.map("passnumber", Result.passnumber) &&

--- a/llvm/tools/llvm-lsp/Protocol.cpp
+++ b/llvm/tools/llvm-lsp/Protocol.cpp
@@ -50,7 +50,8 @@ bool llvm::lsp::fromJSON(const llvm::json::Value &Value,
                          GetIRAfterPassParams &Result, llvm::json::Path Path) {
   llvm::json::ObjectMapper O(Value, Path);
   return O && O.map("uri", Result.uri) && O.map("pipeline", Result.pipeline) &&
-         O.map("passnumber", Result.passnumber);
+         O.map("passnumber", Result.passnumber) &&
+         O.map("additional_opt_args", Result.additional_opt_args);
 }
 
 llvm::json::Value llvm::lsp::toJSON(const IR &Value) {

--- a/llvm/tools/llvm-lsp/Protocol.h
+++ b/llvm/tools/llvm-lsp/Protocol.h
@@ -82,6 +82,8 @@ struct GetIRAfterPassParams {
   std::string pipeline;
   /// The number of the pass in the pipeline after which to return the IR.
   unsigned passnumber;
+  /// Additional arguments passed to opt.
+  std::optional<std::vector<std::string>> additional_opt_args;
 };
 
 bool fromJSON(const llvm::json::Value &Value, GetIRAfterPassParams &Result,

--- a/llvm/tools/llvm-lsp/Protocol.h
+++ b/llvm/tools/llvm-lsp/Protocol.h
@@ -75,18 +75,18 @@ struct PassList {
 
 llvm::json::Value toJSON(const PassList &Value);
 
-struct GetIRAfterPassParams {
+struct GetIRBeforePassParams {
   /// The URI of the `.ll` file for which the intermediate IR is requested.
   URIForFile uri;
   /// The optimization pipeline string, in the format passed to the `opt` tool.
   std::string pipeline;
-  /// The number of the pass in the pipeline after which to return the IR.
+  /// The number of the pass in the pipeline before which to return the IR.
   unsigned passnumber;
   /// Additional arguments passed to opt.
   std::optional<std::vector<std::string>> additional_opt_args;
 };
 
-bool fromJSON(const llvm::json::Value &Value, GetIRAfterPassParams &Result,
+bool fromJSON(const llvm::json::Value &Value, GetIRBeforePassParams &Result,
               llvm::json::Path Path);
 
 struct IR {

--- a/llvm/tools/llvm-lsp/README.md
+++ b/llvm/tools/llvm-lsp/README.md
@@ -148,14 +148,14 @@ interface PassList {
 
 ---
 
-#### `llvm/getIRAfterPass`
+#### `llvm/getIRBeforePass`
 
 This method retrieves the Intermediate Representation (IR) of the code after a specific optimization pass in a pipeline has been applied.
 
 **Parameters**
 
 ```ts
-interface GetIRAfterPassParams {
+interface GetIRBeforePassParams {
     /**
      * The URI of the `.ll` file for which the intermediate IR is requested.
      */
@@ -165,7 +165,7 @@ interface GetIRAfterPassParams {
      */
     pipeline: string;
     /**
-     * The number of the pass in the pipeline after which to return the IR.
+     * The number of the pass in the pipeline before which to return the IR.
      */
     passnumber: uinteger;
     /**

--- a/llvm/tools/llvm-lsp/README.md
+++ b/llvm/tools/llvm-lsp/README.md
@@ -168,6 +168,10 @@ interface GetIRAfterPassParams {
      * The number of the pass in the pipeline after which to return the IR.
      */
     passnumber: uinteger;
+    /**
+     * Additional arguments passed to opt.
+     */
+    additional_opt_args: string[]?;
 }
 ```
 

--- a/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
+++ b/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
@@ -311,7 +311,12 @@ void LspServer::handleRequestGetIRAfterPass(
   IRDocument &Doc = *OpenDocuments[Filepath.str()];
 
   unsigned PassNum = Params.passnumber;
-  auto IRFilePathResult = Doc.getIRAfterPassNumber(Pipeline, PassNum);
+  std::vector<StringRef> PassedAdditionalArgs;
+  if (Params.additional_opt_args)
+    for (const auto &Args : *Params.additional_opt_args)
+      PassedAdditionalArgs.emplace_back(Args);
+  auto IRFilePathResult =
+      Doc.getIRBeforePassNumber(Pipeline, PassNum, PassedAdditionalArgs);
 
   if (!IRFilePathResult) {
     return Reply(IRFilePathResult.takeError());

--- a/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
+++ b/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
@@ -297,8 +297,8 @@ void LspServer::handleRequestGetPassList(const lsp::GetPassListParams &Params,
   Reply(ResponseParams);
 }
 
-void LspServer::handleRequestGetIRAfterPass(
-    const lsp::GetIRAfterPassParams &Params, lsp::Callback<lsp::IR> Reply) {
+void LspServer::handleRequestGetIRBeforePass(
+    const lsp::GetIRBeforePassParams &Params, lsp::Callback<lsp::IR> Reply) {
   StringRef Filepath = Params.uri.file();
   std::string Pipeline = Params.pipeline;
 
@@ -354,8 +354,8 @@ bool LspServer::registerMessageHandlers() {
                         &LspServer::handleRequestBBLocation);
   MessageHandler.method("llvm/getPassList", this,
                         &LspServer::handleRequestGetPassList);
-  MessageHandler.method("llvm/getIRAfterPass", this,
-                        &LspServer::handleRequestGetIRAfterPass);
+  MessageHandler.method("llvm/getIRBeforePass", this,
+                        &LspServer::handleRequestGetIRBeforePass);
 
   ShowMessageSender =
       MessageHandler.outgoingNotification<lsp::ShowMessageParams>(

--- a/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
+++ b/llvm/tools/llvm-lsp/llvm-lsp-server.cpp
@@ -28,6 +28,10 @@ static cl::opt<std::string> LogFilePath("log-file",
                                         cl::init("/tmp/llvm-lsp-server.log"),
                                         cl::cat(LlvmLspServerCategory));
 
+static cl::opt<std::string> OptPath("opt-path", cl::desc("Path to opt file"),
+                                    cl::init(""),
+                                    cl::cat(LlvmLspServerCategory));
+
 static lsp::Position llvmFileLocToLspPosition(const FileLoc &Pos) {
   return lsp::Position(Pos.Line, Pos.Col);
 }
@@ -84,7 +88,9 @@ void LspServer::handleNotificationTextDocumentDidOpen(
 
   // Prepare IRDocument for Queries
   lsp::Logger::info("Creating IRDocument for {}", Filepath.str());
-  OpenDocuments[Filepath.str()] = std::make_unique<IRDocument>(Filepath.str());
+  OpenDocuments[Filepath.str()] = std::make_unique<IRDocument>(
+      Filepath.str(),
+      OptPath == "" ? std::nullopt : std::optional(OptPath.getValue()));
 }
 
 void LspServer::handleRequestGetReferences(

--- a/llvm/tools/llvm-lsp/llvm-lsp-server.h
+++ b/llvm/tools/llvm-lsp/llvm-lsp-server.h
@@ -110,9 +110,9 @@ private:
   void handleRequestGetPassList(const lsp::GetPassListParams &Params,
                                 lsp::Callback<lsp::PassList> Reply);
 
-  // llvm/getIRAfterPAss
-  void handleRequestGetIRAfterPass(const lsp::GetIRAfterPassParams &Params,
-                                   lsp::Callback<lsp::IR> Reply);
+  // llvm/getIRBeforePAss
+  void handleRequestGetIRBeforePass(const lsp::GetIRBeforePassParams &Params,
+                                    lsp::Callback<lsp::IR> Reply);
 
   // Identifies RPC Call and dispatches the handling to other methods
   bool registerMessageHandlers();

--- a/llvm/unittests/tools/CMakeLists.txt
+++ b/llvm/unittests/tools/CMakeLists.txt
@@ -10,3 +10,4 @@ add_subdirectory(
 add_subdirectory(llvm-profdata)
 add_subdirectory(llvm-profgen)
 add_subdirectory(llvm-mca)
+add_subdirectory(llvm-lsp)

--- a/llvm/unittests/tools/llvm-lsp/CMakeLists.txt
+++ b/llvm/unittests/tools/llvm-lsp/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(LLVM_LINK_COMPONENTS
+  Core
+  IRReader
+  Support
+  Analysis
+  Passes
+  SupportLSP
+  TransformUtils
+  AsmParser
+  )
+
+add_llvm_unittest(LspTests
+    OptRunner.cpp
+  )
+
+target_link_libraries(LspTests PRIVATE LLVMTestingSupport)

--- a/llvm/unittests/tools/llvm-lsp/OptRunner.cpp
+++ b/llvm/unittests/tools/llvm-lsp/OptRunner.cpp
@@ -1,0 +1,198 @@
+#include "../tools/llvm-lsp/OptRunner.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/LSP/Logging.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+#include <gtest/gtest.h>
+
+using namespace llvm;
+
+static std::string writeMinimalModuleToTemp(LLVMContext &Ctx) {
+  auto M = std::make_unique<Module>("test_module", Ctx);
+  FunctionType *FT = FunctionType::get(Type::getVoidTy(Ctx), false);
+  Function *F =
+      Function::Create(FT, GlobalValue::ExternalLinkage, "f", M.get());
+  BasicBlock *BB = BasicBlock::Create(Ctx, "entry", F);
+  IRBuilder<> Builder(BB);
+  Builder.CreateRetVoid();
+
+  SmallString<128> TmpFile;
+  std::error_code EC =
+      sys::fs::createTemporaryFile("opt-runner-test", "ll", TmpFile);
+  if (EC)
+    return std::string();
+
+  raw_fd_ostream OS(TmpFile, EC, sys::fs::OF_Text);
+  if (EC)
+    return std::string();
+
+  M->print(OS, nullptr);
+  OS.flush();
+  return std::string(TmpFile.str());
+}
+
+TEST(OptRunner, GetPassList) {
+  LLVMContext Context;
+  std::string TmpFile = writeMinimalModuleToTemp(Context);
+  ASSERT_FALSE(TmpFile.empty());
+
+  // Parse the module again to give OptRunner a Module reference it can clone.
+  SMDiagnostic Err;
+  auto M = parseIRFile(TmpFile, Err, Context);
+  ASSERT_TRUE(static_cast<bool>(M));
+
+  OptRunner Runner(*M, StringRef(TmpFile));
+
+  // runShellOpt: expect success and returned file paths to be readable.
+  llvm::lsp::Logger::setLogLevel(lsp::Logger::Level::Debug);
+
+  auto PassListAndDescriptions =
+      Runner.getPassListAndDescription("default<O2>");
+  ASSERT_TRUE((bool)PassListAndDescriptions);
+  ASSERT_TRUE(PassListAndDescriptions->size() > 0);
+  for (const auto &[Pass, Desc] : *PassListAndDescriptions) {
+    lsp::Logger::debug("Pass: `{}`, Desciption: `{}`", Pass, Desc);
+  }
+  SmallVector<std::pair<std::string, std::string>> ExpectedPasses = {
+      {"1", "Annotation2MetadataPass on [module]"},
+      {"2", "ForceFunctionAttrsPass on [module]"},
+      {"3", "InferFunctionAttrsPass on [module]"},
+      {"4", "CoroEarlyPass on [module]"},
+      {"5", "LowerExpectIntrinsicPass on f"},
+      {"6", "SimplifyCFGPass on f"},
+      {"7", "SROAPass on f"},
+      {"8", "EarlyCSEPass on f"},
+      {"9", "OpenMPOptPass on [module]"},
+      {"10", "IPSCCPPass on [module]"},
+      {"11", "CalledValuePropagationPass on [module]"},
+      {"12", "GlobalOptPass on [module]"},
+      {"13", "PromotePass on f"},
+      {"14", "InstCombinePass on f"},
+      {"15", "SimplifyCFGPass on f"},
+      {"16", "AlwaysInlinerPass on [module]"},
+      {"17", "RequireAnalysisPass<llvm::GlobalsAA, llvm::Module, "
+             "llvm::AnalysisManager<Module>> on [module]"},
+      {"18", "InvalidateAnalysisPass<llvm::AAManager> on f"},
+      {"19", "RequireAnalysisPass<llvm::ProfileSummaryAnalysis, llvm::Module, "
+             "llvm::AnalysisManager<Module>> on [module]"},
+      {"20", "InlinerPass on (f)"},
+      {"21", "PostOrderFunctionAttrsPass on (f)"},
+      {"22", "OpenMPOptCGSCCPass on (f)"},
+      {"23", "SROAPass on f"},
+      {"24", "EarlyCSEPass on f"},
+      {"25", "SpeculativeExecutionPass on f"},
+      {"26", "JumpThreadingPass on f"},
+      {"27", "CorrelatedValuePropagationPass on f"},
+      {"28", "SimplifyCFGPass on f"},
+      {"29", "InstCombinePass on f"},
+      {"30", "AggressiveInstCombinePass on f"},
+      {"31", "LibCallsShrinkWrapPass on f"},
+      {"32", "TailCallElimPass on f"},
+      {"33", "SimplifyCFGPass on f"},
+      {"34", "ReassociatePass on f"},
+      {"35", "ConstraintEliminationPass on f"},
+      {"36", "LoopSimplifyPass on f"},
+      {"37", "LCSSAPass on f"},
+      {"38", "SimplifyCFGPass on f"},
+      {"39", "InstCombinePass on f"},
+      {"40", "LoopSimplifyPass on f"},
+      {"41", "LCSSAPass on f"},
+      {"42", "SROAPass on f"},
+      {"43", "VectorCombinePass on f"},
+      {"44", "MergedLoadStoreMotionPass on f"},
+      {"45", "GVNPass on f"},
+      {"46", "SCCPPass on f"},
+      {"47", "BDCEPass on f"},
+      {"48", "InstCombinePass on f"},
+      {"49", "JumpThreadingPass on f"},
+      {"50", "CorrelatedValuePropagationPass on f"},
+      {"51", "ADCEPass on f"},
+      {"52", "MemCpyOptPass on f"},
+      {"53", "DSEPass on f"},
+      {"54", "MoveAutoInitPass on f"},
+      {"55", "LoopSimplifyPass on f"},
+      {"56", "LCSSAPass on f"},
+      {"57", "CoroElidePass on f"},
+      {"58", "SimplifyCFGPass on f"},
+      {"59", "InstCombinePass on f"},
+      {"60", "PostOrderFunctionAttrsPass on (f)"},
+      {"61", "RequireAnalysisPass<llvm::ShouldNotRunFunctionPassesAnalysis, "
+             "llvm::Function, llvm::AnalysisManager<Function>> on f"},
+      {"62", "CoroSplitPass on (f)"},
+      {"63",
+       "InvalidateAnalysisPass<llvm::ShouldNotRunFunctionPassesAnalysis> on f"},
+      {"64", "DeadArgumentEliminationPass on [module]"},
+      {"65", "CoroCleanupPass on [module]"},
+      {"66", "GlobalOptPass on [module]"},
+      {"67", "GlobalDCEPass on [module]"},
+      {"68", "EliminateAvailableExternallyPass on [module]"},
+      {"69", "ReversePostOrderFunctionAttrsPass on [module]"},
+      {"70", "RecomputeGlobalsAAPass on [module]"},
+      {"71", "Float2IntPass on f"},
+      {"72", "LowerConstantIntrinsicsPass on f"},
+      {"73", "LoopSimplifyPass on f"},
+      {"74", "LCSSAPass on f"},
+      {"75", "LoopDistributePass on f"},
+      {"76", "InjectTLIMappings on f"},
+      {"77", "LoopVectorizePass on f"},
+      {"78", "InferAlignmentPass on f"},
+      {"79", "LoopLoadEliminationPass on f"},
+      {"80", "InstCombinePass on f"},
+      {"81", "SimplifyCFGPass on f"},
+      {"82", "SLPVectorizerPass on f"},
+      {"83", "VectorCombinePass on f"},
+      {"84", "InstCombinePass on f"},
+      {"85", "LoopUnrollPass on f"},
+      {"86", "WarnMissedTransformationsPass on f"},
+      {"87", "SROAPass on f"},
+      {"88", "InferAlignmentPass on f"},
+      {"89", "InstCombinePass on f"},
+      {"90", "LoopSimplifyPass on f"},
+      {"91", "LCSSAPass on f"},
+      {"92", "AlignmentFromAssumptionsPass on f"},
+      {"93", "LoopSinkPass on f"},
+      {"94", "InstSimplifyPass on f"},
+      {"95", "DivRemPairsPass on f"},
+      {"96", "TailCallElimPass on f"},
+      {"97", "SimplifyCFGPass on f"},
+      {"98", "GlobalDCEPass on [module]"},
+      {"99", "ConstantMergePass on [module]"},
+      {"100", "CGProfilePass on [module]"},
+      {"101", "RelLookupTableConverterPass on [module]"},
+      {"102", "AnnotationRemarksPass on f"},
+      {"103", "BitcodeWriterPass on [module]"}};
+
+  // This assert fails for some reason, but the elementvise comparison doesnt
+  // ASSERT_EQ(*PassListAndDescriptions, ExpectedPasses);
+  for (const auto &[A, B] : zip(*PassListAndDescriptions, ExpectedPasses)) {
+    ASSERT_EQ(A, B);
+  }
+}
+
+TEST(OptRunner, GetModuleAfterPass) {
+  LLVMContext Context;
+  std::string TmpFile = writeMinimalModuleToTemp(Context);
+  ASSERT_FALSE(TmpFile.empty());
+
+  // Parse the module again to give OptRunner a Module reference it can
+  // clone.
+  SMDiagnostic Err;
+  auto M = parseIRFile(TmpFile, Err, Context);
+  ASSERT_TRUE(static_cast<bool>(M));
+
+  OptRunner Runner(*M, StringRef(TmpFile));
+
+  // runShellOpt: expect success and returned file paths to be readable.
+  llvm::lsp::Logger::setLogLevel(lsp::Logger::Level::Debug);
+
+  auto MaybeModule = Runner.getModuleAfterPass("default<O2>", 10);
+  ASSERT_TRUE((bool)MaybeModule);
+
+  ASSERT_TRUE(*MaybeModule);
+
+  for (const auto & F : M->functions()){
+    ASSERT_TRUE((*MaybeModule)->getFunction(F.getName()));
+  }
+}

--- a/llvm/unittests/tools/llvm-lsp/OptRunner.cpp
+++ b/llvm/unittests/tools/llvm-lsp/OptRunner.cpp
@@ -176,7 +176,7 @@ TEST(OptRunner, GetModuleAfterPass) {
 
   OptRunner Runner(*M, StringRef(TmpFile));
 
-  auto MaybeModule = Runner.getModuleAfterPass("default<O2>", 10);
+  auto MaybeModule = Runner.getModuleBeforePass("default<O2>", 10);
   ASSERT_TRUE((bool)MaybeModule);
 
   ASSERT_TRUE(*MaybeModule);

--- a/llvm/unittests/tools/llvm-lsp/OptRunner.cpp
+++ b/llvm/unittests/tools/llvm-lsp/OptRunner.cpp
@@ -38,23 +38,17 @@ TEST(OptRunner, GetPassList) {
   std::string TmpFile = writeMinimalModuleToTemp(Context);
   ASSERT_FALSE(TmpFile.empty());
 
-  // Parse the module again to give OptRunner a Module reference it can clone.
   SMDiagnostic Err;
   auto M = parseIRFile(TmpFile, Err, Context);
   ASSERT_TRUE(static_cast<bool>(M));
 
   OptRunner Runner(*M, StringRef(TmpFile));
 
-  // runShellOpt: expect success and returned file paths to be readable.
-  llvm::lsp::Logger::setLogLevel(lsp::Logger::Level::Debug);
-
   auto PassListAndDescriptions =
       Runner.getPassListAndDescription("default<O2>");
   ASSERT_TRUE((bool)PassListAndDescriptions);
   ASSERT_TRUE(PassListAndDescriptions->size() > 0);
-  for (const auto &[Pass, Desc] : *PassListAndDescriptions) {
-    lsp::Logger::debug("Pass: `{}`, Desciption: `{}`", Pass, Desc);
-  }
+
   SmallVector<std::pair<std::string, std::string>> ExpectedPasses = {
       {"1", "Annotation2MetadataPass on [module]"},
       {"2", "ForceFunctionAttrsPass on [module]"},
@@ -176,16 +170,11 @@ TEST(OptRunner, GetModuleAfterPass) {
   std::string TmpFile = writeMinimalModuleToTemp(Context);
   ASSERT_FALSE(TmpFile.empty());
 
-  // Parse the module again to give OptRunner a Module reference it can
-  // clone.
   SMDiagnostic Err;
   auto M = parseIRFile(TmpFile, Err, Context);
   ASSERT_TRUE(static_cast<bool>(M));
 
   OptRunner Runner(*M, StringRef(TmpFile));
-
-  // runShellOpt: expect success and returned file paths to be readable.
-  llvm::lsp::Logger::setLogLevel(lsp::Logger::Level::Debug);
 
   auto MaybeModule = Runner.getModuleAfterPass("default<O2>", 10);
   ASSERT_TRUE((bool)MaybeModule);

--- a/llvm/unittests/tools/llvm-lsp/OptRunner.cpp
+++ b/llvm/unittests/tools/llvm-lsp/OptRunner.cpp
@@ -46,7 +46,8 @@ TEST(OptRunner, GetPassList) {
 
   auto PassListAndDescriptions =
       Runner.getPassListAndDescription("default<O2>");
-  ASSERT_TRUE((bool)PassListAndDescriptions);
+  ASSERT_TRUE((bool)PassListAndDescriptions)
+      << PassListAndDescriptions.takeError();
   ASSERT_TRUE(PassListAndDescriptions->size() > 0);
 
   SmallVector<std::pair<std::string, std::string>> ExpectedPasses = {
@@ -174,14 +175,20 @@ TEST(OptRunner, GetModuleAfterPass) {
   auto M = parseIRFile(TmpFile, Err, Context);
   ASSERT_TRUE(static_cast<bool>(M));
 
+  SmallString<1024> TmpResult;
+  sys::fs::createTemporaryFile("opt-runner-test", "ll", TmpResult);
+
   OptRunner Runner(*M, StringRef(TmpFile));
 
-  auto MaybeModule = Runner.getModuleBeforePass("default<O2>", 10);
-  ASSERT_TRUE((bool)MaybeModule);
+  auto MaybeModulePath =
+      Runner.getModuleBeforePass("default<O2>", 10, TmpResult);
+  ASSERT_TRUE((bool)MaybeModulePath);
 
-  ASSERT_TRUE(*MaybeModule);
+  auto ResultModule = parseIRFile(TmpFile, Err, Context);
+
+  ASSERT_TRUE(ResultModule.get());
 
   for (const auto & F : M->functions()){
-    ASSERT_TRUE((*MaybeModule)->getFunction(F.getName()));
+    ASSERT_TRUE((ResultModule)->getFunction(F.getName()));
   }
 }

--- a/llvm/utils/vscode/llvm/src/llvmPipeline.ts
+++ b/llvm/utils/vscode/llvm/src/llvmPipeline.ts
@@ -3,7 +3,7 @@ import { Command } from './command';
 import { LLVMContext } from './llvmContext';
 import {
   LlvmGetPassList,
-  LlvmGetIRAfterPass,
+  LlvmGetIRBeforePass,
 } from './lspCustomMessages';
 
 export class LLVMGetIRCommand extends Command {
@@ -127,15 +127,15 @@ export class LLVMGetIRCommand extends Command {
     this.context.outputChannel.appendLine(`You selected Pass: ${selectedPass} and PassNumber ${passNum}`);
 
     // Query server for filepath
-    let result2: LlvmGetIRAfterPass.Response = undefined;
+    let result2: LlvmGetIRBeforePass.Response = undefined;
     try {
-      const params: LlvmGetIRAfterPass.Params = {
+      const params: LlvmGetIRBeforePass.Params = {
         uri: currentFileUri.toString(),
         passnumber: passNum,
         pipeline: pipeline
       };
 
-      const response = await client.sendRequest(LlvmGetIRAfterPass.Type, params);
+      const response = await client.sendRequest(LlvmGetIRBeforePass.Type, params);
       result2 = response;
     } catch (error) {
       this.context.outputChannel.appendLine(`Error during custom request LlvmGetPassList: ${error}`);

--- a/llvm/utils/vscode/llvm/src/llvmPipeline.ts
+++ b/llvm/utils/vscode/llvm/src/llvmPipeline.ts
@@ -122,7 +122,7 @@ export class LLVMGetIRCommand extends Command {
     }
 
     const selectedPass = selected.label;
-    const passNumMatch = selectedPass.match(/^(\d+)-/);
+    const passNumMatch = selectedPass.match(/^(\d+)/);
     const passNum = passNumMatch ? parseInt(passNumMatch[1]) : 0;
     this.context.outputChannel.appendLine(`You selected Pass: ${selectedPass} and PassNumber ${passNum}`);
 

--- a/llvm/utils/vscode/llvm/src/lspCustomMessages.ts
+++ b/llvm/utils/vscode/llvm/src/lspCustomMessages.ts
@@ -49,14 +49,15 @@ export namespace LlvmGetPassList {
   export const Type = new RequestType<Params, Response, void>('llvm/getPassList');
 }
 
-export namespace LlvmGetIRAfterPass {
+export namespace LlvmGetIRBeforePass {
   export interface Params {
     uri: URI;
     passnumber: uinteger;
     pipeline: String;
+    additional_opt_args?: [string];
   }
   export interface Response {
     uri: URI;
   }
-  export const Type = new RequestType<Params, Response, void>('llvm/getIRAfterPass');
+  export const Type = new RequestType<Params, Response, void>('llvm/getIRBeforePass');
 }


### PR DESCRIPTION
Use external opt to get pass list and execute pipelines.

Makes two temp files for the output of opt.
Allows the user to pass in the location of opt as a cli argument of the lsp server. While allowing for additional arguments to opt being passed at runtime.

Also added some tests for this feature.